### PR TITLE
first hbef munge kernel ready

### DIFF
--- a/data/general/site_data.csv
+++ b/data/general/site_data.csv
@@ -1,13 +1,13 @@
 "domain","pretty_domain","network","pretty_network","stream","site_name","full_name","site_type","latitude","longitude","ws_area_ha","in_workflow","notes"
-"hbef","HBEF","lter","LTER","Stream 1","W1","Watershed 1","stream_gauge",43.952034,-71.726501,11.8,1,
-"hbef","HBEF","lter","LTER","Stream 2","W2","Watershed 2","stream_gauge",43.953358,-71.724174,15.6,1,
-"hbef","HBEF","lter","LTER","Stream 3","W3","Watershed 3","stream_gauge",43.954875,-71.722816,42.4,1,
-"hbef","HBEF","lter","LTER","Stream 4","W4","Watershed 4","stream_gauge",43.950176,-71.725792,36.1,1,
-"hbef","HBEF","lter","LTER","Stream 5","W5","Watershed 5","stream_gauge",43.948845,-71.731918,21.9,1,
-"hbef","HBEF","lter","LTER","Stream 6","W6","Watershed 6","stream_gauge",43.94994,-71.735641,13.2,1,
-"hbef","HBEF","lter","LTER","Stream 7","W7","Watershed 7","stream_gauge",43.927509,-71.767075,77.38,1,
-"hbef","HBEF","lter","LTER","Stream 8","W8","Watershed 8","stream_gauge",43.929436,-71.759521,59.4,1,
-"hbef","HBEF","lter","LTER","Stream 9","W9","Watershed 9","stream_gauge",43.926014,-71.747195,68.4,1,
+"hbef","HBEF","lter","LTER","Stream 1","w1","Watershed 1","stream_gauge",43.952034,-71.726501,11.8,1,
+"hbef","HBEF","lter","LTER","Stream 2","w2","Watershed 2","stream_gauge",43.953358,-71.724174,15.6,1,
+"hbef","HBEF","lter","LTER","Stream 3","w3","Watershed 3","stream_gauge",43.954875,-71.722816,42.4,1,
+"hbef","HBEF","lter","LTER","Stream 4","w4","Watershed 4","stream_gauge",43.950176,-71.725792,36.1,1,
+"hbef","HBEF","lter","LTER","Stream 5","w5","Watershed 5","stream_gauge",43.948845,-71.731918,21.9,1,
+"hbef","HBEF","lter","LTER","Stream 6","w6","Watershed 6","stream_gauge",43.94994,-71.735641,13.2,1,
+"hbef","HBEF","lter","LTER","Stream 7","w7","Watershed 7","stream_gauge",43.927509,-71.767075,77.38,1,
+"hbef","HBEF","lter","LTER","Stream 8","w8","Watershed 8","stream_gauge",43.929436,-71.759521,59.4,1,
+"hbef","HBEF","lter","LTER","Stream 9","w9","Watershed 9","stream_gauge",43.926014,-71.747195,68.4,1,
 "hbef","HBEF","lter","LTER",,"RG1","Rain Gauge 1","rain_gauge",43.952120788912,-71.7248377271807,,1,"converted shapefile from lter using st_transform"
 "hbef","HBEF","lter","LTER",,"RG11","Rain Gauge 11","rain_gauge",43.9502266292999,-71.7346124400276,,1,"converted shapefile from lter using st_transform"
 "hbef","HBEF","lter","LTER",,"RG23","Rain Gauge 23","rain_gauge",43.9272011309167,-71.746926195465,,1,"converted shapefile from lter using st_transform"

--- a/data/general/variables.csv
+++ b/data/general/variables.csv
@@ -1,62 +1,62 @@
-"variable_code","variable_name","unit","method","variable_type","variable_subtype","R_display","valence","flux_convertible"
-"Al_ICP","Aluminum ICP","mg/L","UNKNOWN","grab","Cations","expression(Al^'+3')",3,1
-"OMAl","Aluminum OM","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",3,1
-"TMAl","Aluminum TM","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",3,1
-"NH4","Ammonium","mg/L","UNKNOWN","grab","Cations","expression(NH^'+4')",4,1
-"Ca","Calcium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Ca^'+2')",2,1
-"Cl","Chloride","mg/L","ion chromatography","grab","Anions","expression(Cl^'-')",1,1
-"F","Fluorine","mg/L","UNKNOWN","grab","Anions","expression(F^'-')",1,1
-"Fe","Iron","mg/L","UNKNOWN","grab","Cations","expression(UNKNOWN)",2.5,1
-"Mg","Magnesium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Mg^'+2')",2,1
-"Mn","Manganese","mg/L","UNKNOWN","grab","Cations","expression(UNKNOWN)",3,1
-"NO3","Nitrate","mg/L","UNKNOWN","grab","Anions","expression(NO[3]^'-')",1,1
-"PO4","Phosphate","mg/L","UNKNOWN","grab","Anions","expression(PO[4]^'-3')",3,1
-"K","Potassium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(K^'+')",1,1
-"Na","Sodium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Na^'+')",1,1
-"SO4","Sulfate","mg/L","UNKNOWN","grab","Anions","expression(SO[4]^'-2')",2,1
-"anionCharge","TOTAL Anion Charge","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"cationCharge","TOTAL Cation Charge","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"pH","pH","unitless","glass electrode","grab","Other","expression(UNKNOWN)",,0
-"pHmetrohm","pH Metrohm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"DOC","Dissolved Organic Carbon","mg/L","combustion","grab","Other","expression(UNKNOWN)",1,1
-"TDN","Total Dissolved Nitrogen","mg/L","persulfate digestion -  calorimetric analysis","grab","Other","expression(UNKNOWN)",1,1
-"DON","Dissolved Organic Nitrogen","mg/L","derived","grab","Other","expression(UNKNOWN)",1,1
-"DIC","Dissolved Inorganic Carbon","M/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"SiO2","Silica","UNKNOWN","molybdenum blue","grab","Other","expression(SiO[2])",1,1
-"ANC960","Acid Neutralizing Capacity 960","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"ANCMet","Acid Neutralizing Capacity Met","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"spCond","Specific Conductivity","S/cm","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"theoryCond","Theoretical Conductivity","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"temp","Water Temperature","degrees C","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"ionBalance","Ion Balance","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"precipCatch","Catchment Precipitation","mm","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"flowGageHt","Discharge","L/s","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"alk","Alkalinity","mg/L","electrometric titration to pH 4.5","grab","Other","expression(UNKNOWN)",,1
-"suspSed","Suspended Sediment","mg/L","gravimetric","grab","Other","expression(UNKNOWN)",,1
-"NH4_N","Ammonium-N","mg/L","phenate method","grab","Cations","expression(UNKNOWN)",4,1
-"NO3_N","Nitrate-N","mg/L","cadmium reduction","grab","Anions","expression(UNKNOWN)",1,1
-"PO4_P","Phosphate-P","mg/L","ascorbic acid","grab","Anions","expression(UNKNOWN)",3,1
-"SO4_S","Sulfate-S","mg/L","ion chromatography","grab","Anions","expression(UNKNOWN)",2,1
-"TDP","Total Dissolved Phosphorus","mg/L","persulfate digestion - ascorbic acid finish","grab","Other","expression(UNKNOWN)",1,1
-"TKN","Total Kjeldahl Nitrogen","mg/L","Kjeldahl digestion - nessler finish","grab","Other","expression(UNKNOWN)",1,1
-"UTKN","Unfilt. Total Kjeldahl Nitrogen","mg/L","Kjeldahl digestion - nessler finish","grab","Other","expression(UNKNOWN)",1,1
-"UTN","Unfiltered Total Nitrogen","mg/L","persulfate digestion - calorimetric analysis","grab","Other","expression(UNKNOWN)",1,1
-"UTP","Unfiltered Total Phosphorus","mg/L","persulfate digestion - ascorbic acid finish","grab","Other","expression(UNKNOWN)",1,1
-"ANC","Acid Neutralizing Capacity","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"Br","Bromide","mg/L","UNKNOWN","grab","Anions","expression(Br^'-')",1,1
-"CO3","Carbonate","mg/L","UNKNOWN","grab","Anions","expression(CO[3]^'-2')",2,1
-"DIC","Dissolved Inorganic Carbon","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"HCO3","Bicarbonate","mg/L","UNKNOWN","grab","Anions","expression(HCO[3]^'-')",3,1
-"NO2_N","Nitrite-N","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"NO3_NO2_N","Nitrate-N and nitrite-N","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"Si","Silicon","mg/L","UNKNOWN","grab","Anions","expression(Si^'-4')",4,1
-"TDS","Total Dissolved Solids","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"TN","Total Nitrogen","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"TOC","Total Organic Carbon","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"TP","Total Phosphorus","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1
-"TPC","Total Particulate Carbon","mg","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"TPN","Total Particulate Nitrogen","mg","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"TSS","Total Suspended Solids","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"abs250","UV Absorbance at 250nm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"abs280","UV Absorbance at 280nm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
-"PAR","Photosynthetically Active Radiation","uM/m^2/s","UNKNOWN","grab","Other","expression(UNKNOWN)",,0
+"variable_code","variable_name","unit","method","variable_type","variable_subtype","R_display","valence","flux_convertible","notes"
+"Al_ICP","Aluminum ICP","mg/L","UNKNOWN","grab","Cations","expression(Al^'+3')",3,1,
+"OMAl","Aluminum OM","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",3,1,
+"TMAl","Aluminum TM","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",3,1,
+"NH4","Ammonium","mg/L","UNKNOWN","grab","Cations","expression(NH^'+4')",4,1,"should always be converted to NH4-N. remove this row once hbef munging complete"
+"Ca","Calcium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Ca^'+2')",2,1,
+"Cl","Chloride","mg/L","ion chromatography","grab","Anions","expression(Cl^'-')",1,1,
+"F","Fluorine","mg/L","UNKNOWN","grab","Anions","expression(F^'-')",1,1,
+"Fe","Iron","mg/L","UNKNOWN","grab","Cations","expression(UNKNOWN)",2.5,1,
+"Mg","Magnesium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Mg^'+2')",2,1,
+"Mn","Manganese","mg/L","UNKNOWN","grab","Cations","expression(UNKNOWN)",3,1,
+"NO3","Nitrate","mg/L","UNKNOWN","grab","Anions","expression(NO[3]^'-')",1,1,"should always be converted to NO3-N. remove this row once hbef munging complete"
+"PO4","Phosphate","mg/L","UNKNOWN","grab","Anions","expression(PO[4]^'-3')",3,1,"should always be converted to PO4-P. remove this row once hbef munging complete"
+"K","Potassium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(K^'+')",1,1,
+"Na","Sodium","mg/L","flame atomic absorption spectroscopy","grab","Cations","expression(Na^'+')",1,1,
+"SO4","Sulfate","mg/L","UNKNOWN","grab","Anions","expression(SO[4]^'-2')",2,1,
+"anionCharge","TOTAL Anion Charge","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"cationCharge","TOTAL Cation Charge","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"pH","pH","unitless","glass electrode","grab","Other","expression(UNKNOWN)",,0,
+"pHmetrohm","pH Metrohm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"DOC","Dissolved Organic Carbon","mg/L","combustion","grab","Other","expression(UNKNOWN)",1,1,
+"TDN","Total Dissolved Nitrogen","mg/L","persulfate digestion -  calorimetric analysis","grab","Other","expression(UNKNOWN)",1,1,
+"DON","Dissolved Organic Nitrogen","mg/L","derived","grab","Other","expression(UNKNOWN)",1,1,
+"DIC","Dissolved Inorganic Carbon","M/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"SiO2","Silica","UNKNOWN","molybdenum blue","grab","Other","expression(SiO[2])",1,1,
+"ANC960","Acid Neutralizing Capacity 960","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"ANCMet","Acid Neutralizing Capacity Met","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"spCond","Specific Conductivity","S/cm","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"theoryCond","Theoretical Conductivity","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"temp","Water Temperature","degrees C","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"ionBalance","Ion Balance","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"precip","Catchment Precipitation","mm","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"discharge","Discharge","L/s","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"alk","Alkalinity","mg/L","electrometric titration to pH 4.5","grab","Other","expression(UNKNOWN)",,1,
+"suspSed","Suspended Sediment","mg/L","gravimetric","grab","Other","expression(UNKNOWN)",,1,
+"NH4_N","Ammonium-N","mg/L","phenate method","grab","Cations","expression(UNKNOWN)",4,1,
+"NO3_N","Nitrate-N","mg/L","cadmium reduction","grab","Anions","expression(UNKNOWN)",1,1,
+"PO4_P","Phosphate-P","mg/L","ascorbic acid","grab","Anions","expression(UNKNOWN)",3,1,
+"SO4_S","Sulfate-S","mg/L","ion chromatography","grab","Anions","expression(UNKNOWN)",2,1,
+"TDP","Total Dissolved Phosphorus","mg/L","persulfate digestion - ascorbic acid finish","grab","Other","expression(UNKNOWN)",1,1,
+"TKN","Total Kjeldahl Nitrogen","mg/L","Kjeldahl digestion - nessler finish","grab","Other","expression(UNKNOWN)",1,1,
+"UTKN","Unfilt. Total Kjeldahl Nitrogen","mg/L","Kjeldahl digestion - nessler finish","grab","Other","expression(UNKNOWN)",1,1,
+"UTN","Unfiltered Total Nitrogen","mg/L","persulfate digestion - calorimetric analysis","grab","Other","expression(UNKNOWN)",1,1,
+"UTP","Unfiltered Total Phosphorus","mg/L","persulfate digestion - ascorbic acid finish","grab","Other","expression(UNKNOWN)",1,1,
+"ANC","Acid Neutralizing Capacity","eq/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"Br","Bromide","mg/L","UNKNOWN","grab","Anions","expression(Br^'-')",1,1,
+"CO3","Carbonate","mg/L","UNKNOWN","grab","Anions","expression(CO[3]^'-2')",2,1,
+"DIC","Dissolved Inorganic Carbon","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"HCO3","Bicarbonate","mg/L","UNKNOWN","grab","Anions","expression(HCO[3]^'-')",3,1,
+"NO2_N","Nitrite-N","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"NO3_NO2_N","Nitrate-N and nitrite-N","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"Si","Silicon","mg/L","UNKNOWN","grab","Anions","expression(Si^'-4')",4,1,
+"TDS","Total Dissolved Solids","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"TN","Total Nitrogen","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"TOC","Total Organic Carbon","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"TP","Total Phosphorus","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",1,1,
+"TPC","Total Particulate Carbon","mg","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"TPN","Total Particulate Nitrogen","mg","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"TSS","Total Suspended Solids","mg/L","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"abs250","UV Absorbance at 250nm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"abs280","UV Absorbance at 280nm","unitless","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,
+"PAR","Photosynthetically Active Radiation","uM/m^2/s","UNKNOWN","grab","Other","expression(UNKNOWN)",,0,

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -38,7 +38,7 @@ network_domain = sm(read_csv('data/general/site_data.csv')) %>%
 
 ms_globals = c(ls(all.names=TRUE), 'email_err_msgs')
 
-# dmnrow=3
+# dmnrow=1
 for(dmnrow in 1:nrow(network_domain)){
 
     network = network_domain$network[dmnrow]

--- a/src/function_aliases.R
+++ b/src/function_aliases.R
@@ -34,3 +34,6 @@ str_match = stringr::str_match
 loginfo = logging::loginfo
 logwarn = logging::logwarn
 logerror = logging::logerror
+with_tz = lubridate::with_tz
+force_tz = lubridate::force_tz
+as_datetime = lubridate::as_datetime

--- a/src/global_helpers.R
+++ b/src/global_helpers.R
@@ -183,6 +183,8 @@ export_to_global <- function(from_env, exclude=NULL){
     for(i in 1:length(varnames)){
         assign(varnames[i], vars[[i]], .GlobalEnv)
     }
+
+    return()
 }
 
 #. handle_errors
@@ -220,6 +222,8 @@ get_all_local_helpers <- function(network=domain, domain){
 
     export_to_global(from_env=environment(),
         exclude=c('network', 'domain', 'thisenv'))
+
+    return()
 }
 
 #. handle_errors
@@ -259,6 +263,8 @@ clear_from_mem <- function(..., clearlist){
 
     rm(list=clearlist, envir=.GlobalEnv)
     gc()
+
+    return()
 }
 
 #. handle_errors
@@ -268,6 +274,8 @@ retain_ms_globals <- function(retain_vars){
     clutter = all_globals[! all_globals %in% retain_vars]
 
     clear_from_mem(clearlist=clutter)
+
+    return()
 }
 
 generate_ms_err = function(text=1){
@@ -530,7 +538,7 @@ backup_tracker <- function(path){
         recursive=TRUE, showWarnings=FALSE)
 
     tstamp = Sys.time() %>%
-        lubridate::with_tz(tzone='UTC') %>%
+        with_tz(tzone='UTC') %>%
         format('%Y%m%dT%HZ') #tstamp format: YYYYMMDDTHHZ
 
     newpath = glue('{p}/tracker_backups/{f}_{t}', p=mch[1], f=mch[2], t=tstamp)
@@ -583,6 +591,7 @@ prodcode_from_prodname_ms <- function(prodname_ms){
 #. handle_errors
 ms_retrieve <- function(network=domain, domain){
     source(glue('src/{n}/{d}/retrieve.R', n=network, d=domain))
+    return()
 }
 
 #. handle_errors
@@ -630,6 +639,7 @@ serialize_list_to_dir <- function(l, dest){
         }
     }
 
+    return()
 }
 
 #. handle_errors

--- a/src/lter/hbef/domain_helpers.R
+++ b/src/lter/hbef/domain_helpers.R
@@ -1,0 +1,57 @@
+
+#. handle_errors
+munge_hbef_site <- function(domain, site, prodname_ms, tracker, silent=TRUE){
+    # site=sites[j]; tracker=held_data
+
+    retrieval_log = extract_retrieval_log(held_data, prodname_ms, site)
+
+    if(nrow(retrieval_log) == 0){
+        return(generate_ms_err('missing retrieval log'))
+    }
+
+    out = tibble()
+    for(k in 1:nrow(retrieval_log)){
+
+        prodcode = prodcode_from_prodname_ms(prodname_ms)
+
+        processing_func = get(paste0('process_1_', prodcode))
+        in_comp = retrieval_log[k, 'component']
+
+        out_comp = sw(do.call(processing_func,
+            args=list(network=network, domain=domain, prodname_ms=prodname_ms,
+                site_name=site, component=in_comp)))
+
+        if(! is_ms_err(out_comp) && ! is_ms_exception(out_comp)){
+            out = bind_rows(out, out_comp)
+        }
+    }
+
+    prod_dir = glue('data/{n}/{d}/munged/{p}', n=network, d=domain,
+        p=prodname_ms)
+    dir.create(prod_dir, showWarnings=FALSE, recursive=TRUE)
+    site_file = glue('{pd}/{s}.feather', pd=prod_dir, s=site)
+    write_feather(out, site_file)
+
+    portal_prod_dir = glue('../portal/data/{d}/{p}',
+        d=domain, p=strsplit(prodname_ms, '_')[[1]][1])
+    dir.create(portal_prod_dir, showWarnings=FALSE, recursive=TRUE)
+    portal_site_file = glue('{pd}/{s}.feather', pd=portal_prod_dir, s=site)
+
+    #if there's already a data file for this site-time-product in the portal
+    #repo, remove it
+    unlink(portal_site_file)
+
+    #create a link to the new file from the portal repo
+    #(from and to seem logically reversed in file.link)
+    invisible(sw(file.link(to=portal_site_file, from=site_file)))
+
+    update_data_tracker_m(network=network, domain=domain,
+        tracker_name='held_data', prodname_ms=prodname_ms, site=site,
+        new_status='ok')
+
+    msg = glue('munged {p} ({n}/{d}/{s})',
+        p=prodname_ms, n=network, d=domain, s=site)
+    loginfo(msg, logger=logger_module)
+
+    return('sitemunge complete')
+}

--- a/src/lter/hbef/munge.R
+++ b/src/lter/hbef/munge.R
@@ -19,7 +19,7 @@ for(i in 1:nrow(prod_info)){
 
     for(j in 1:length(sites)){
 
-        munge_msg = munge_neon_site(domain, sites[j], prodname_ms, held_data)
+        munge_msg = munge_hbef_site(domain, sites[j], prodname_ms, held_data)
 
         if(is_ms_err(munge_msg)){
             update_data_tracker_m(network=network, domain=domain,
@@ -29,4 +29,6 @@ for(i in 1:nrow(prod_info)){
     }
 
     gc()
+    loginfo('Munging complete for all sites and products',
+        logger=logger_module)
 }

--- a/src/lter/hbef/processing_kernels.R
+++ b/src/lter/hbef/processing_kernels.R
@@ -1,6 +1,6 @@
+#retrieval kernels ####
 
-#retrieval kernels
-
+#discharge: STATUS=READY
 #. handle_errors
 process_0_1 <- function(set_details, network, domain){
 
@@ -15,4 +15,39 @@ process_0_1 <- function(set_details, network, domain){
 
 } #discharge: ready
 
-#munge kernels
+#precip: STATUS=PENDING
+#. handle_errors
+process_0_13 <- function(set_details, network, domain){
+    NULL
+}
+
+#munge kernels ####
+
+#discharge: STATUS=READY
+#. handle_errors
+process_1_1 <- function(network, domain, prodname_ms, site_name,
+    component){
+    # site_name=site; component=in_comp
+
+    rawfile = glue('data/{n}/{d}/raw/{p}/{s}/{c}',
+        n=network, d=domain, p=prodname_ms, s=site_name, c=component)
+
+    d = sw(read_csv(rawfile, progress=FALSE,
+        col_types=readr::cols_only(
+            DATETIME='c', #can't parse 24:00
+            WS='c',
+            Discharge_ls='d'))) %>%
+            # Flag='c'))) %>% #all flags are acceptable for this product
+        rename(site_name = WS,
+            datetime = DATETIME,
+            discharge = Discharge_ls) %>%
+        mutate(
+            datetime = with_tz(force_tz(as.POSIXct(datetime), 'US/Eastern'), 'UTC'),
+            # datetime = with_tz(as_datetime(datetime, 'US/Eastern'), 'UTC'),
+            site_name = paste0('w', site_name)) %>%
+        group_by(datetime, site_name) %>%
+        summarize(discharge = mean(discharge, na.rm=TRUE)) %>%
+        ungroup()
+
+    return(d)
+}

--- a/src/lter/hbef/products.csv
+++ b/src/lter/hbef/products.csv
@@ -1,5 +1,5 @@
 prodcode,prodname,type,retrieve_status,munge_status,derive_status,notes,NA_status
-1,discharge,unknown,pending,pending,pending,NA,NA
+1,discharge,unknown,ready,ready,pending,NA,NA
 13,precipitation,unknown,pending,pending,pending,see also product 14,NA
 208,stream_precip_chemistry,unknown,pending,pending,pending,NA,NA
 5482,rain_gauge_locations,unknown,paused,pending,pending,NA,NA

--- a/src/lter/hbef/retrieve.R
+++ b/src/lter/hbef/retrieve.R
@@ -1,8 +1,8 @@
-
 prod_info = get_product_info(network=network, domain=domain,
     status_level='retrieve', get_statuses='ready')
+    # status_level='retrieve', get_statuses='pending')
 
-# i=1; j=3
+# i=1; j=1
 for(i in 1:nrow(prod_info)){
 # for(i in 1){
 
@@ -24,8 +24,8 @@ for(i in 1:nrow(prod_info)){
 
     #retrieve data by site; log acquisitions and revisions
     avail_sites = unique(avail_sets$site_name)
-    for(j in 1){
-    # for(j in 1:length(avail_sites)){
+    # for(j in 1){
+    for(j in 1:length(avail_sites)){
 
         curr_site = avail_sites[j]
         avail_site_sets = avail_sets[avail_sets$site_name == curr_site, ,
@@ -58,4 +58,6 @@ for(i in 1:nrow(prod_info)){
     }
 
     gc()
+    loginfo('Retrieval complete for all sites and products',
+        logger=logger_module)
 }

--- a/src/lter/network_helpers.R
+++ b/src/lter/network_helpers.R
@@ -109,4 +109,3 @@ get_lter_data <- function(domain, sets, tracker, silent=TRUE){
         }
     }
 }
-

--- a/src/neon/neon/munge.R
+++ b/src/neon/neon/munge.R
@@ -31,4 +31,6 @@ for(i in 1:nrow(prod_info)){
     }
 
     gc()
+    loginfo('Munging complete for all sites and products',
+        logger=logger_module)
 }

--- a/src/neon/neon/processing_kernels.R
+++ b/src/neon/neon/processing_kernels.R
@@ -247,7 +247,7 @@ process_1_DP1.20093 <- function(network, domain, prodname_ms, site_name,
         mutate_at(vars(one_of('conductivity')), function(x) x / 1e6) %>% #uS/cm -> S/cm
         mutate(
             site_name = site_name,
-            collectDate = lubridate::force_tz(collectDate, 'UTC')) %>%
+            collectDate = force_tz(collectDate, 'UTC')) %>%
         rename_all(dplyr::recode, siteID='site_name', collectDate='datetime',
             conductivity='spCond', `NH4 - N`='NH4_N', `NO2 - N`='NO2_N',
             `NO3+NO2 - N`='NO3_NO2_N', `Ortho - P`='PO4_P',
@@ -289,7 +289,7 @@ process_1_DP1.20033 <- function(network, domain, prodname_ms, site_name,
     out_sub = out_sub %>%
         mutate(
             site_name=paste0(siteID, updown), #append "-up" to upstream site_names
-            startDateTime = lubridate::force_tz(startDateTime, 'UTC'), #GMT -> UTC
+            startDateTime = force_tz(startDateTime, 'UTC'), #GMT -> UTC
             surfWaterNitrateMean = surfWaterNitrateMean * N_mass / 1000) %>% #uM/L NO3 -> mg/L N
         # filter(finalQF == 0) %>% #remove flagged records
         group_by(startDateTime, site_name) %>%
@@ -333,7 +333,7 @@ process_1_DP1.20042 <- function(network, domain, prodname_ms, site_name,
     out_sub = out_sub %>%
         mutate(
             site_name=paste0(siteID, updown), #append "-up" to upstream site_names
-            startDateTime = lubridate::force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
+            startDateTime = force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
         group_by(startDateTime, site_name) %>%
         summarize(
             PARMean = mean(PARMean, na.rm=TRUE),
@@ -374,7 +374,7 @@ process_1_DP1.20053 <- function(network, domain, prodname_ms, site_name,
     out_sub = out_sub %>%
         mutate(
             site_name=paste0(siteID, updown), #append "-up" to upstream site_names
-            startDateTime = lubridate::force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
+            startDateTime = force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
         group_by(startDateTime, site_name) %>%
         summarize(
             surfWaterTempMean = mean(surfWaterTempMean, na.rm=TRUE),
@@ -415,7 +415,7 @@ process_1_DP1.00004 <- function(network, domain, prodname_ms, site_name,
     out_sub = out_sub %>%
         mutate(
             site_name=paste0(siteID, updown), #append "-up" to upstream site_names
-            startDateTime = lubridate::force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
+            startDateTime = force_tz(startDateTime, 'UTC')) %>% #GMT -> UTC
         group_by(startDateTime, site_name) %>%
         summarize(
             staPresMean = mean(staPresMean, na.rm=TRUE),

--- a/src/neon/neon/retrieve.R
+++ b/src/neon/neon/retrieve.R
@@ -54,4 +54,6 @@ for(i in 1:nrow(prod_info)){
     }
 
     gc()
+    loginfo('Retrieval complete for all sites and products',
+        logger=logger_module)
 }


### PR DESCRIPTION
@spencerrhea
also @matthewross07 (just for a bit of an update; also note that style changes have not yet been made yet, but totes will). 

note that some lubridate functions are now included in function_aliases.R. Feel free to add commonly used non-base-loaded package functions into that script whenever. I can show you how to use `sed` to recursively modify text in all R files, which will let us update all instances of e.g. `lubridate::with_tz()` to just `with_tz()` whenever we make these kinds of global changes. 

there's also a new file: src/lter/hbef/domain_helpers.R, with one function (munge_hbef_site). This is the first time we've had a helper that is domain-specific. after we've dealt with several LTER domains, we might realize they're all structured similarly enough that it makes sense to move this function into network_helpers.R and rename it munge_lter_site.