### PR TITLE
more bugfixes

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -198,7 +198,9 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-dmnrow=3
+# drop_automated_entries('.') #use with caution!
+
+dmnrow=9
 # for(dmnrow in 1:nrow(network_domain)){
 for(dmnrow in c(1:5, 7:10)){
 

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -154,7 +154,7 @@ ms_init <- function(use_gpu = FALSE,
     return(instance_details)
 }
 
-ms_instance <- ms_init(use_ms_error_handling = FALSE,
+ms_instance <- ms_init(use_ms_error_handling = TRUE,
                        force_machine_status = 'n00b')
 
 #load authorization file for macrosheds google sheets
@@ -198,15 +198,16 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=6
-for(dmnrow in 1:nrow(network_domain)){
+dmnrow=3
+# for(dmnrow in 1:nrow(network_domain)){
+for(dmnrow in c(1:5, 7:10)){
 
     network <- network_domain$network[dmnrow]
     domain <- network_domain$domain[dmnrow]
 
     # held_data = invalidate_tracked_data(network, domain, 'derive', prodname_ms)
     # held_data = invalidate_tracked_data(network, domain, 'derive')
-    # owrite_tracker()
+    # owrite_tracker(network, domain)
 
     logger_module = set_up_logger(network = network,
                                   domain = domain)
@@ -230,8 +231,8 @@ for(dmnrow in 1:nrow(network_domain)){
                     verbose = TRUE))
     ms_derive(network = network,
               domain = domain)
-    ms_general(network = network,
-               domain = domain)
+    # ms_general(network = network,
+    #            domain = domain)
 
     retain_ms_globals(ms_globals)
 }

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -206,6 +206,8 @@ for(dmnrow in c(1:5, 7:10)){
     domain <- network_domain$domain[dmnrow]
 
     # held_data = invalidate_tracked_data(network, domain, 'derive', prodname_ms)
+    # held_data = invalidate_tracked_data(network, domain, 'munge')
+    # owrite_tracker(network, domain)
     # held_data = invalidate_tracked_data(network, domain, 'derive')
     # owrite_tracker(network, domain)
 

--- a/src/dev/dev_helpers.R
+++ b/src/dev/dev_helpers.R
@@ -1,4 +1,4 @@
-owrite_tracker = function(trck){
+owrite_tracker = function(network, domain, trck){
     tracker_path = glue::glue('data/{n}/{d}/data_tracker.json',
         n=network, d=domain)
     if(! missing(trck)) held_data = trck
@@ -579,14 +579,22 @@ invalidate_all = function(){
 
         network <- network_domain$network[dmnrow]
         domain <- network_domain$domain[dmnrow]
+        print(network); print(domain)
 
-        held_data = invalidate_tracked_data(network = network,
+        tr = invalidate_tracked_data(network = network,
                                             domain = domain,
                                             level = 'munge')
-        owrite_tracker(held_data)
-        held_data = invalidate_tracked_data(network = network,
+
+        if(domain == 'hbef') print(tr$discharge__1$w1)
+        owrite_tracker(network, domain, tr)
+        if(domain == 'hbef'){
+            tr2 = get_data_tracker(network, domain)
+            print(tr2$discharge__1$w1)
+        }
+
+        tr = invalidate_tracked_data(network = network,
                                             domain = domain,
                                             level = 'derive')
-        owrite_tracker(held_data)
+        owrite_tracker(network, domain, tr)
     }
 }

--- a/src/dev/dev_helpers.R
+++ b/src/dev/dev_helpers.R
@@ -598,3 +598,18 @@ invalidate_all = function(){
         owrite_tracker(network, domain, tr)
     }
 }
+
+drop_automated_entries <- function(path = '.'){
+
+    #this drops rows with "automated entry" from all products.csv files
+    #found below the specified path
+
+    system(glue("find {p} -name 'products.csv' | ",
+                "xargs sed -e '/automated entry/d' -i.TMPBAK",
+                p = path))
+
+    system(glue("find <<p>> -name '*.TMPBAK' -exec rm {} \\;",
+                p = path,
+                .open = '<<',
+                .close = '>>'))
+}

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -1997,8 +1997,10 @@ update_data_tracker_r <- function(network = domain,
 
         tracker[[set_details$prodname_ms]][[set_details$site_name]]$retrieve = rt
 
+        print(ls(envir = .GlobalEnv))
         assign(tracker_name, tracker, pos=.GlobalEnv)
     }
+    print(tracker)
 
     trackerdir <- glue('data/{n}/{d}', n=network, d=domain)
     if(! dir.exists('trackerdir')){
@@ -2307,18 +2309,18 @@ ms_retrieve <- function(network=domain, domain){
     #and the errors should be fixed via variable passing. the chunk below attempts
     #to fix some foreseen errors
 
-    #source was previously called with default local = FALSE, which was populating
-    #the global environment with a lot of variables. Some of them we've learned
-    #to expect in the global env, so i'm restoring them here for back-compatibility
-    #now that local = TRUE. Easier than passing them explicitly through our
-    #complex call tree
-    assign(x = 'held_data',
-           value = held_data,
-           envir = .GlobalEnv)
-
-    assign(x = 'prodname_ms',
-           value = prodname_ms,
-           envir = .GlobalEnv)
+    # #source was previously called with default local = FALSE, which was populating
+    # #the global environment with a lot of variables. Some of them we've learned
+    # #to expect in the global env, so i'm restoring them here for back-compatibility
+    # #now that local = TRUE. Easier than passing them explicitly through our
+    # #complex call tree
+    # assign(x = 'held_data',
+    #        value = held_data,
+    #        envir = .GlobalEnv)
+    #
+    # assign(x = 'prodname_ms',
+    #        value = prodname_ms,
+    #        envir = .GlobalEnv)
 }
 
 ms_munge <- function(network = domain, domain){
@@ -2330,18 +2332,18 @@ ms_munge <- function(network = domain, domain){
     #and the errors should be fixed via variable passing. the chunk below attempts
     #to fix some foreseen errors
 
-    #source was previously called with default local = FALSE, which was populating
-    #the global environment with a lot of variables. Some of them we've learned
-    #to expect in the global env, so i'm restoring them here for back-compatibility
-    #now that local = TRUE. Easier than passing them explicitly through our
-    #complex call tree
-    assign(x = 'held_data',
-           value = held_data,
-           envir = .GlobalEnv)
-
-    assign(x = 'prodname_ms',
-           value = prodname_ms,
-           envir = .GlobalEnv)
+    # #source was previously called with default local = FALSE, which was populating
+    # #the global environment with a lot of variables. Some of them we've learned
+    # #to expect in the global env, so i'm restoring them here for back-compatibility
+    # #now that local = TRUE. Easier than passing them explicitly through our
+    # #complex call tree
+    # assign(x = 'held_data',
+    #        value = held_data,
+    #        envir = .GlobalEnv)
+    #
+    # assign(x = 'prodname_ms',
+    #        value = prodname_ms,
+    #        envir = .GlobalEnv)
 }
 
 ms_delineate <- function(network, domain,
@@ -3010,6 +3012,7 @@ get_derive_ingredient <- function(network,
                                   domain,
                                   prodname,
                                   ignore_derprod = FALSE,
+                                  ignore_derprod900 = TRUE,
                                   accept_multiple = FALSE){
 
     #get prodname_ms's by prodname, for specifying derive kernels.
@@ -3017,6 +3020,8 @@ get_derive_ingredient <- function(network,
     #ignore_derprod: logical. if TRUE, don't consider any product with an
     #   msXXX prodcode. In other words, return a munged prodname_ms. If FALSE,
     #   derived products take precedence over munged products.
+    #ignore_derprod900: logical. if TRUE, don't consider any product with an
+    #   ms9XX prodcode.
     #accept_multi_ing: logical. should more than one ingredient be returned?
 
      prods <- sm(read_csv(glue('src/{n}/{d}/products.csv',
@@ -3046,6 +3051,11 @@ get_derive_ingredient <- function(network,
                                        prodcode,
                                        sep = '__')) %>%
             pull(prodname_ms)
+
+        if(ignore_derprod900){
+            prodname_ms <- prodname_ms[! grepl(pattern = '__ms9[0-9]{2}$',
+                                               x = prodname_ms)]
+        }
 
         #if there are multiple derive kernels, we're looking for the one that is
         #   a precursor to the other, so grab the one with the lower msXXX ID.

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -1997,10 +1997,8 @@ update_data_tracker_r <- function(network = domain,
 
         tracker[[set_details$prodname_ms]][[set_details$site_name]]$retrieve = rt
 
-        print(ls(envir = .GlobalEnv))
         assign(tracker_name, tracker, pos=.GlobalEnv)
     }
-    print(tracker)
 
     trackerdir <- glue('data/{n}/{d}', n=network, d=domain)
     if(! dir.exists('trackerdir')){

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -2344,7 +2344,8 @@ ms_munge <- function(network = domain, domain){
     #        envir = .GlobalEnv)
 }
 
-ms_delineate <- function(network, domain,
+ms_delineate <- function(network,
+                         domain,
                          dev_machine_status,
                          verbose = FALSE){
 
@@ -2561,12 +2562,14 @@ ms_delineate <- function(network, domain,
                                        possible_chars = c(1:nshapes, 'S', 'A'))
 
             if(resp == 'S'){
+                unlink(site_dir)
                 message(glue('Moving on. You haven\'t seen the last of {s}!',
                               s = site))
                 next
             }
 
             if(resp == 'A'){
+                unlink(site_dir)
                 message('Aborted. Completed delineations have been saved')
                 return()
             }
@@ -3496,7 +3499,8 @@ ms_calc_watershed_area <- function(network, domain, site_name, level, update_sit
 
         ms_write_confdata(site_data,
                           which_dataset = 'site_data',
-                          to_where = ms_instance$config_data_storage)
+                          to_where = ms_instance$config_data_storage,
+                          overwrite = TRUE)
     }
 
     return(ws_area_ha)
@@ -3513,11 +3517,12 @@ write_wb_delin_specs <- function(network, domain, site_name, buffer_radius,
                         snap_distance_m = snap_distance,
                         dem_resolution = dem_resolution)
 
-    ws_delin_specs <- bind_rows(ws_delin_specs, new_entry)
+    # ws_delin_specs <- bind_rows(ws_delin_specs, new_entry)
 
-    ms_write_confdata(ws_delin_specs,
-                      which_dataset = 'watershed_delineation_specs',
-                      to_where = ms_instance$config_data_storage)
+    ms_write_confdata(new_entry,
+                      which_dataset = 'ws_delin_specs',
+                      to_where = ms_instance$config_data_storage,
+                      overwrite = FALSE)
 
     #return()
 }
@@ -4676,7 +4681,7 @@ shortcut_idw_concflux_v2 <- function(encompassing_dem,
     #dump_idw_precip: logical; if TRUE, IDW-interpolated precipitation will
     #   be dumped to disk (data/<network>/<domain>/precip_idw_dumps/<site_name>.rds).
     #   this file will then be read by precip_pchem_pflux_idw, in order to
-    #   properly buiild data/<network>/<domain>/derived/<precipitation_msXXX>.
+    #   properly build data/<network>/<domain>/derived/<precipitation_msXXX>.
     #   the precip_idw_dumps directory is automatically removed after it's used.
     #   This should only be set to TRUE for one iteration of the calling loop,
     #   or else time will be wasted rewriting the files.
@@ -4787,13 +4792,6 @@ shortcut_idw_concflux_v2 <- function(encompassing_dem,
         quickref_ind <- k %% 1000
         update_quickref <- quickref_ind == 0
 
-        # if(update_quickref){
-        #
-        #     # quickref_chunk <- quickref_chunk + 1
-        #     # quickref_chunk <- floor((k - 1) / 1000) + 1
-        #
-        # }
-
         ## GET PRECIP FOR ALL CELLS IN TIMESTEP k
 
         if(quickref_status == 'reading'){
@@ -4892,18 +4890,10 @@ shortcut_idw_concflux_v2 <- function(encompassing_dem,
         errors(ws_mean_conc)[k] <- mean(errors(c_idw), na.rm=TRUE)
         errors(ws_mean_flux)[k] <- mean(errors(flux_interp), na.rm=TRUE)
 
-        # if(return_precip){
-        #     ws_mean_precip[k] <- mean(p_idw, na.rm=TRUE)
-        #     errors(ws_mean_precip)[k] <- mean(errors(p_idw), na.rm=TRUE)
-        # }
         if(dump_idw_precip){
 
             ws_mean_precip[k] <- mean(p_idw, na.rm=TRUE)
             errors(ws_mean_precip)[k] <- mean(errors(p_idw), na.rm=TRUE)
-
-            # if(any(is.na(precip_varnames))){
-            #     stop('NA detected in precip_varnames')
-            # }
 
             ws_means_precip <- tibble(
                 datetime = d_dt,
@@ -5015,6 +5005,11 @@ dump_precip_idw_tempfile <- function(ws_means,
                                      domain,
                                      site_name){
 
+    #not to be confused with precip quickref, the tempfile (dumpfile) communicates
+    #precipitation data used in flux calculation up the callstack from
+    #shortcut_idw_concflux_v2 to precip_pchem_pflux_idw, so that the precip
+    #product can be generated for free, as a byproduct
+
     dumpdir <- glue('data/{n}/{d}/precip_idw_dumps/',
                     n = network,
                     d = domain)
@@ -5032,6 +5027,11 @@ dump_precip_idw_tempfile <- function(ws_means,
 load_precip_idw_tempfile <- function(network,
                                      domain,
                                      site_name){
+
+    #not to be confused with precip quickref, the tempfile (dumpfile) communicates
+    #precipitation data used in flux calculation up the callstack from
+    #shortcut_idw_concflux_v2 to precip_pchem_pflux_idw, so that the precip
+    #product can be generated for free, as a byproduct
 
     dumpfile <- glue('data/{n}/{d}/precip_idw_dumps/{s}.rds',
                      n = network,
@@ -5052,21 +5052,35 @@ save_precip_quickref <- function(precip_idw_list,
                                  # chunk_number){
                                  timestep){
 
+    #not to be confused with the precip idw tempfile (dumpfile),
+    #the quickref file allows the same precip idw data to be used across all
+    #chemistry variables when calculating flux. it's stored in 1000-timestep
+    #chunks
+
     chunk_number <- floor((timestep - 1) / 1000) + 1
     chunkID <- stringr::str_pad(string = chunk_number,
                                 width = 3,
                                 side = 'left',
                                 pad = '0')
 
-    chunkfile <- glue('data/{n}/{d}/precip_idw_quickref/{s}/chunk{ch}.rds}',
-                      n = network,
-                      d = domain,
-                      s = site_name,
+    quickref_dir <- glue('data/{n}/{d}/precip_idw_quickref/{s}',
+                         n = network,
+                         d = domain,
+                         s = site_name)
+
+    chunkfile <- glue('chunk{ch}.rds',
                       ch = chunkID)
 
     if(! file.exists(chunkfile)){ #in case another thread has already written it
+
+        dir.create(path = quickref_dir,
+                   showWarnings = FALSE,
+                   recursive = TRUE)
+
         saveRDS(object = precip_idw_list,
-                file = chunkfile)
+                file = paste(quickref_dir,
+                             chunkfile,
+                             sep = '/'))
     }
 }
 
@@ -5075,8 +5089,13 @@ try_read_precip_quickref <- function(network,
                                      site_name,
                                      timestep){
 
+    #not to be confused with the precip idw tempfile (dumpfile),
+    #the quickref file allows the same precip idw data to be used across all
+    #chemistry variables when calculating flux. it's stored in 1000-timestep
+    #chunks
+
     #set timestep to 0 to get the first chunk. for every thousand timepoints
-    #   thereafter, it will grab the next chunk
+    #thereafter, it will grab the next chunk
 
     chunk_number <- timestep / 1000 + 1
 
@@ -5566,7 +5585,6 @@ precip_pchem_pflux_idw <- function(pchem_prodname,
     if(nrow(precip) == 0){
         stop('the test code removed all the precip data. change test_switch')
     }
-
 
     for(i in 1:nrow(wb)){
 
@@ -7265,25 +7283,31 @@ load_config_datasets <- function(from_where){
            pos = .GlobalEnv)
 }
 
-ms_write_confdata <- function(x, which_dataset, to_where){
+ms_write_confdata <- function(x,
+                              which_dataset,
+                              to_where,
+                              overwrite = FALSE){
 
     #x: a tibble or data.frame
-    #which_dataset: string. either "variables", "site_data", "univ_products",
-    #   "name_variants", or "watershed_delineation_specs"
+    #which_dataset: string. either "ms_vars", "site_data", "univ_products",
+    #   "name_variants", or "ws_delin_specs"
     #to_where: string. either "remote", meaning write this file to a google
     #   sheets connection defined in data_acquisition/config.json and
     #   data_acquisition/googlesheet_service_accnt.json, or "local", meaning
     #   write this file locally to data_acquisition/data/general/<which_dataset>.csv
+    #overwrite: logical; If FALSE, x will be appended to which_dataset
 
     #this writes our "configuration" datasets to their appropriate locations.
-    #as of 10/27/20 those datasets include site_data, variables, universal_products,
-    #name_variants, and watershed_delineation_specs.
+    #as of 10/27/20 those datasets include site_data, ms_vars, universal_products,
+    #name_variants, and ws_delin_specs
     #depending on the type of instance (remote/local),
     #those datasets are either written to local CSVs or to google sheets. for ms
     #developers, this will always be "remote". for future users, it'll be a
     #configurable option.
 
-    known_datasets <- c('variables', 'site_data', 'watershed_delineation_specs',
+    #which_dataset will also be updated in memory
+
+    known_datasets <- c('ms_vars', 'site_data', 'ws_delin_specs',
                         'univ_products', 'name_variants')
 
     if(! which_dataset %in% known_datasets){
@@ -7294,33 +7318,60 @@ ms_write_confdata <- function(x, which_dataset, to_where){
     if(to_where == 'remote'){
 
         write_loc <- case_when(
-            which_dataset == 'variables' ~ conf$variables_gsheet,
+            which_dataset == 'ms_vars' ~ conf$variables_gsheet,
             which_dataset == 'site_data' ~ conf$site_data_gsheet,
             which_dataset == 'univ_products' ~ conf$univ_prods_gsheet,
             which_dataset == 'name_variants' ~ conf$name_variant_gsheet,
-            which_dataset == 'watershed_delineation_specs' ~
-                conf$delineation_gsheet)
+            which_dataset == 'ws_delin_specs' ~ conf$delineation_gsheet)
 
-        sm(googlesheets4::write_sheet(data = x,
-                                      ss = write_loc,
-                                      sheet = 1))
+        if(overwrite){
+            sm(googlesheets4::write_sheet(data = x,
+                                          ss = write_loc,
+                                          sheet = 1))
+        } else {
+            sm(googlesheets4::sheet_append(data = x,
+                                           ss = write_loc,
+                                           sheet = 1))
+        }
+
+        dset <- sm(googlesheets4::read_sheet(ss = write_loc,
+                                             na = c('', 'NA')))
 
     } else if(to_where == 'local'){
 
         write_loc <- case_when(
-            which_dataset == 'variables' ~ 'variables.csv',
+            which_dataset == 'ms_vars' ~ 'variables.csv',
             which_dataset == 'site_data' ~ 'site_data.csv',
             which_dataset == 'univ_products' ~ 'universal_products.csv',
             which_dataset == 'name_variants' ~ 'name_variants.csv',
-            which_dataset == 'watershed_delineation_specs' ~
-                'watershed_delineation_specs.csv')
+            which_dataset == 'ws_delin_specs' ~ 'watershed_delineation_specs.csv')
 
-        write_csv(x,
-                  path = paste0('data/general/',
-                                write_loc))
+        if(overwrite){
+
+            write_csv(x,
+                      path = paste0('data/general/',
+                                    write_loc))
+        } else {
+
+            dset <- read_csv(path = paste0('data/general/',
+                                           write_loc))
+            dset <- bind_rows(dset, x)
+
+            write_csv(x = dset,
+                      path = paste0('data/general/',
+                                    write_loc))
+        }
+
+        dset <- read_csv(path = paste0('data/general/',
+                                       write_loc))
+
     } else {
         stop('to_where must be either "local" or "remote"')
     }
+
+    assign(x = which_dataset,
+           value = dset,
+           envir = .GlobalEnv)
 }
 
 filter_single_samp_sites <- function(df) {

--- a/src/lter/baltimore/derive.R
+++ b/src/lter/baltimore/derive.R
@@ -10,18 +10,18 @@ prod_info <- get_product_info(network = network,
 for(i in 1:nrow(prod_info)){
     # for(i in 2){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
 
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
             
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                               prodname_ms = prodname_ms,
                                               site_name = site_name,
                                               site_components = 'NA')

--- a/src/lter/baltimore/munge.R
+++ b/src/lter/baltimore/munge.R
@@ -49,6 +49,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/baltimore/munge.R
+++ b/src/lter/baltimore/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/baltimore/products.csv
+++ b/src/lter/baltimore/products.csv
@@ -10,3 +10,5 @@ ms012,stream_chemistry,NA,NA,ready,stream_flux_inst_ms003,NA
 ms011,discharge,NA,NA,ready,stream_flux_inst_ms003,NA
 ms003,stream_flux_inst,NA,NA,ready,NA,NA
 ms001,precip_pchem_pflux,NA,NA,ready,NA,NA
+ms015,ws_boundary,NA,NA,linked,NA,automated entry
+ms900,precipitation,NA,NA,NA,NA,automated entry

--- a/src/lter/baltimore/products.csv
+++ b/src/lter/baltimore/products.csv
@@ -10,5 +10,3 @@ ms012,stream_chemistry,NA,NA,ready,stream_flux_inst_ms003,NA
 ms011,discharge,NA,NA,ready,stream_flux_inst_ms003,NA
 ms003,stream_flux_inst,NA,NA,ready,NA,NA
 ms001,precip_pchem_pflux,NA,NA,ready,NA,NA
-ms015,ws_boundary,NA,NA,linked,NA,automated entry
-ms900,precipitation,NA,NA,NA,NA,automated entry

--- a/src/lter/baltimore/retrieve.R
+++ b/src/lter/baltimore/retrieve.R
@@ -8,12 +8,12 @@ prod_info <- get_product_info(network = network,
 # i=4
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn = get_latest_product_version(prodname_ms = prodname_ms,
@@ -40,11 +40,11 @@ for(i in 1:nrow(prod_info)){
                                      drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-                held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+                held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                                   site_components=avail_site_sets$component)
                 }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                                avail_site_sets)
 
         if(is_ms_err(held_data)) next

--- a/src/lter/bonanza/derive.R
+++ b/src/lter/bonanza/derive.R
@@ -9,18 +9,18 @@ prod_info <- get_product_info(network = network,
 # i=4
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
 
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
 
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                               prodname_ms = prodname_ms,
                                               site_name = site_name,
                                               site_components = 'NA')

--- a/src/lter/bonanza/munge.R
+++ b/src/lter/bonanza/munge.R
@@ -61,6 +61,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/bonanza/munge.R
+++ b/src/lter/bonanza/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/bonanza/products.csv
+++ b/src/lter/bonanza/products.csv
@@ -9,8 +9,3 @@ ms006,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms005,NA
 ms007,stream_gauge_locations,NA,NA,ready,NA,NA
 ms004,stream_flux_inst,NA,NA,ready,NA,NA
 ms005,precip_pchem_pflux,NA,NA,ready,NA,NA
-ms000,ws_boundary,NA,NA,NA,precip_pchem_pflux__ms005,automated entry
-ms008,discharge,NA,NA,linked,NA,automated entry
-ms900,precipitation,NA,NA,NA,NA,automated entry
-ms901,precip_chemistry,NA,NA,NA,NA,automated entry
-ms902,precip_flux_inst,NA,NA,NA,NA,automated entry

--- a/src/lter/bonanza/products.csv
+++ b/src/lter/bonanza/products.csv
@@ -9,3 +9,5 @@ ms006,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms005,NA
 ms007,stream_gauge_locations,NA,NA,ready,NA,NA
 ms004,stream_flux_inst,NA,NA,ready,NA,NA
 ms005,precip_pchem_pflux,NA,NA,ready,NA,NA
+ms000,ws_boundary,NA,NA,NA,precip_pchem_pflux__ms005,automated entry
+ms008,discharge,NA,NA,linked,NA,automated entry

--- a/src/lter/bonanza/retrieve.R
+++ b/src/lter/bonanza/retrieve.R
@@ -8,12 +8,12 @@ prod_info <- get_product_info(network = network,
 # i=5
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-            held_data = track_new_product(held_data, prodname_ms)
+            held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms = prodname_ms,
@@ -38,11 +38,11 @@ for(i in 1:nrow(prod_info)){
                                      drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                               site_components=avail_site_sets$component)
             }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                                avail_site_sets)
 
         if(is_ms_err(held_data)) next

--- a/src/lter/coweeta/derive.R
+++ b/src/lter/coweeta/derive.R
@@ -8,16 +8,16 @@ prod_info = get_product_info(network=network, domain=domain,
 for(i in 1:nrow(prod_info)){
   # for(i in 2){
   
-  prodname_ms = paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+  prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
   
-  held_data = get_data_tracker(network=network, domain=domain)
+  held_data <<- get_data_tracker(network=network, domain=domain)
   
   if(! product_is_tracked(held_data, prodname_ms)){
     
     if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-      held_data <- track_new_product(tracker = held_data,
+      held_data <<- track_new_product(tracker = held_data,
                                      prodname_ms = prodname_ms)
-      held_data <- insert_site_skeleton(tracker = held_data,
+      held_data <<- insert_site_skeleton(tracker = held_data,
                                         prodname_ms = prodname_ms,
                                         site_name = site_name,
                                         site_components = 'NA')

--- a/src/lter/coweeta/munge.R
+++ b/src/lter/coweeta/munge.R
@@ -54,6 +54,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/coweeta/munge.R
+++ b/src/lter/coweeta/munge.R
@@ -9,7 +9,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
       logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/coweeta/retrieve.R
+++ b/src/lter/coweeta/retrieve.R
@@ -6,12 +6,12 @@ prod_info = get_product_info(network=network, domain=domain,
 # i=8
 for(i in 1:nrow(prod_info)){
         
-        prodname_ms = glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+        prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
         
-        held_data = get_data_tracker(network=network, domain=domain)
+        held_data <<- get_data_tracker(network=network, domain=domain)
         
         if(! product_is_tracked(held_data, prodname_ms)){
-                held_data = track_new_product(held_data, prodname_ms)
+                held_data <<- track_new_product(held_data, prodname_ms)
         }
         
         latest_vsn = get_latest_product_version(prodname_ms=prodname_ms,
@@ -47,11 +47,11 @@ for(i in 1:nrow(prod_info)){
                                              drop=FALSE]
                 
                 if(! site_is_tracked(held_data, prodname_ms, site_name)){
-                        held_data = insert_site_skeleton(held_data, prodname_ms, site_name,
+                        held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                                          site_components=avail_site_sets$component)
                 }
                 
-                held_data = track_new_site_components(held_data, prodname_ms, site_name,
+                held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                                       avail_site_sets)
                 if(is_ms_err(held_data)) next
                 

--- a/src/lter/hbef/derive.R
+++ b/src/lter/hbef/derive.R
@@ -9,17 +9,17 @@ prod_info <- get_product_info(network = network,
 # i=1
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network,
+    held_data <<- get_data_tracker(network = network,
                                  domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                              prodname_ms = prodname_ms,
                                              site_name = site_name,
                                              site_components = 'NA')

--- a/src/lter/hbef/munge.R
+++ b/src/lter/hbef/munge.R
@@ -11,7 +11,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network,
+    held_data <<- get_data_tracker(network = network,
                                   domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){

--- a/src/lter/hbef/munge.R
+++ b/src/lter/hbef/munge.R
@@ -61,6 +61,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/hbef/products.csv
+++ b/src/lter/hbef/products.csv
@@ -8,3 +8,7 @@ prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 107,stream_gauge_locations,ready,ready,NA,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA
 ms002,precip_pchem_pflux,NA,NA,ready,NA,NA
+ms003,discharge,NA,NA,linked,NA,automated entry
+ms004,precip_gauge_locations,NA,NA,linked,NA,automated entry
+ms005,ws_boundary,NA,NA,linked,NA,automated entry
+ms007,stream_gauge_locations,NA,NA,linked,NA,automated entry

--- a/src/lter/hbef/products.csv
+++ b/src/lter/hbef/products.csv
@@ -8,7 +8,3 @@ prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 107,stream_gauge_locations,ready,ready,NA,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA
 ms002,precip_pchem_pflux,NA,NA,ready,NA,NA
-ms003,discharge,NA,NA,linked,NA,automated entry
-ms004,precip_gauge_locations,NA,NA,linked,NA,automated entry
-ms005,ws_boundary,NA,NA,linked,NA,automated entry
-ms007,stream_gauge_locations,NA,NA,linked,NA,automated entry

--- a/src/lter/hbef/products.csv
+++ b/src/lter/hbef/products.csv
@@ -8,11 +8,3 @@ prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 107,stream_gauge_locations,ready,ready,NA,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA
 ms002,precip_pchem_pflux,NA,NA,ready,NA,NA
-ms003,discharge,NA,NA,linked,NA,automated entry
-ms004,precip_gauge_locations,NA,NA,linked,NA,automated entry
-ms005,ws_boundary,NA,NA,linked,NA,automated entry
-ms006,stream_chemistry,NA,NA,linked,NA,automated entry
-ms007,stream_gauge_locations,NA,NA,linked,NA,automated entry
-ms900,precipitation,NA,NA,NA,NA,automated entry
-ms901,precip_chemistry,NA,NA,NA,NA,automated entry
-ms902,precip_flux_inst,NA,NA,NA,NA,automated entry

--- a/src/lter/hbef/retrieve.R
+++ b/src/lter/hbef/retrieve.R
@@ -9,12 +9,12 @@ prod_info <- get_product_info(network = network,
 for(i in 1:nrow(prod_info)){
 # for(i in 1){
 
-    prodname_ms <-  glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms = prodname_ms,
@@ -45,11 +45,11 @@ for(i in 1:nrow(prod_info)){
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
 
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                 site_components=avail_site_sets$component)
         }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
             avail_site_sets)
 
         if(is_ms_err(held_data)) next

--- a/src/lter/hbef/retrieve.R
+++ b/src/lter/hbef/retrieve.R
@@ -2,7 +2,7 @@ loginfo('Beginning retrieve', logger=logger_module)
 
 prod_info <- get_product_info(network = network,
                               domain = domain,
-                              status_level = 'retrieve', 
+                              status_level = 'retrieve',
                               get_statuses = 'ready')
 
 # i=2
@@ -18,14 +18,14 @@ for(i in 1:nrow(prod_info)){
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms = prodname_ms,
-                                             domain = domain, 
+                                             domain = domain,
                                              data_tracker = held_data)
 
     if(is_ms_err(latest_vsn)) next
 
     avail_sets = get_avail_lter_product_sets(prodname_ms = prodname_ms,
-                                             version = latest_vsn, 
-                                             domain = domain, 
+                                             version = latest_vsn,
+                                             domain = domain,
                                              data_tracker = held_data)
 
     if(is_ms_err(avail_sets)) next
@@ -88,7 +88,7 @@ for(i in 1:nrow(prod_info)){
                          'packageid=knb-lter-hbr.{p}.{v}',
                          p = prodcode_from_prodname_ms(prodname_ms),
                          v = latest_vsn)
-    
+
     write_metadata_r(murl = metadata_url,
                      network = network,
                      domain = domain,

--- a/src/lter/hjandrews/derive.R
+++ b/src/lter/hjandrews/derive.R
@@ -11,14 +11,14 @@ prod_info <- get_product_info(network = network,
 
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
     # assign(x = 'prodname_ms',
     #        value = paste0(prod_info$prodname[i],
     #                       '__',
     #                       prod_info$prodcode[i]),
     #        envir = .GlobalEnv)
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
     # assign(x = 'held_data',
     #        value = get_data_tracker(network = network,
     #                                 domain = domain),
@@ -27,9 +27,9 @@ for(i in 1:nrow(prod_info)){
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                              prodname_ms = prodname_ms,
                                              site_name = site_name,
                                              site_components = 'NA')

--- a/src/lter/hjandrews/munge.R
+++ b/src/lter/hjandrews/munge.R
@@ -48,6 +48,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/hjandrews/products.csv
+++ b/src/lter/hjandrews/products.csv
@@ -14,11 +14,3 @@ prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 3239,stream_gauge_locations,ready,ready,pending,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA
 ms002,precip_pchem_pflux,NA,NA,ready,NA,NA
-ms003,stream_chemistry,NA,NA,linked,NA,automated entry
-ms004,precip_gauge_locations,NA,NA,linked,NA,automated entry
-ms005,discharge,NA,NA,linked,NA,automated entry
-ms006,ws_boundary,NA,NA,linked,NA,automated entry
-ms007,stream_gauge_locations,NA,NA,linked,NA,automated entry
-ms900,precipitation,NA,NA,NA,NA,automated entry
-ms901,precip_chemistry,NA,NA,NA,NA,automated entry
-ms902,precip_flux_inst,NA,NA,NA,NA,automated entry

--- a/src/lter/hjandrews/retrieve.R
+++ b/src/lter/hjandrews/retrieve.R
@@ -8,12 +8,12 @@ prod_info <- get_product_info(network = network,
 # i=1
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms=prodname_ms,
@@ -38,11 +38,11 @@ for(i in 1:nrow(prod_info)){
             drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                 site_components=avail_site_sets$component)
         }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
             avail_site_sets)
         if(is_ms_err(held_data)) next
 

--- a/src/lter/konza/derive.R
+++ b/src/lter/konza/derive.R
@@ -9,16 +9,16 @@ prod_info <- get_product_info(network = network,
 # i=6
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                               prodname_ms = prodname_ms,
                                               site_name = site_name,
                                               site_components = 'NA')

--- a/src/lter/konza/munge.R
+++ b/src/lter/konza/munge.R
@@ -53,6 +53,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/konza/munge.R
+++ b/src/lter/konza/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/konza/products.csv
+++ b/src/lter/konza/products.csv
@@ -16,9 +16,3 @@ ms001,discharge,NA,NA,ready,stream_flux_inst_ms003,NA,NA
 ms002,stream_chemistry,NA,NA,ready,stream_flux_inst_ms003,NA,NA
 ms003,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms004,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
-ms000,ws_boundary,NA,NA,NA,NA,automated entry,NA
-ms005,precip_gauge_locations,NA,NA,linked,NA,automated entry,NA
-ms006,stream_gauge_locations,NA,NA,linked,NA,automated entry,NA
-ms900,precipitation,NA,NA,NA,NA,automated entry,NA
-ms901,precip_chemistry,NA,NA,NA,NA,automated entry,NA
-ms902,precip_flux_inst,NA,NA,NA,NA,automated entry,NA

--- a/src/lter/konza/retrieve.R
+++ b/src/lter/konza/retrieve.R
@@ -8,13 +8,13 @@ prod_info <- get_product_info(network = network,
 # i = 1
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network,
+    held_data <<- get_data_tracker(network = network,
                                   domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms = prodname_ms,
@@ -46,13 +46,13 @@ for(i in 1:nrow(prod_info)){
                                       drop = FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data,
+            held_data <<- insert_site_skeleton(held_data,
                                               prodname_ms,
                                               site_name,
                                               site_components = avail_site_sets$component)
         }
 
-        held_data <- track_new_site_components(held_data,
+        held_data <<- track_new_site_components(held_data,
                                                prodname_ms,
                                                site_name,
                                                avail_site_sets)

--- a/src/lter/luquillo/munge.R
+++ b/src/lter/luquillo/munge.R
@@ -48,6 +48,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/luquillo/munge.R
+++ b/src/lter/luquillo/munge.R
@@ -11,7 +11,7 @@ for(i in 1:nrow(prod_info)){
     prodname_ms <<- paste0(prod_info$prodname[i],
                           '__',
                           prod_info$prodcode[i])
-    held_data <- get_data_tracker(network = network,
+    held_data <<- get_data_tracker(network = network,
                                   domain = domain)
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/luquillo/retrieve.R
+++ b/src/lter/luquillo/retrieve.R
@@ -5,12 +5,12 @@ prod_info = get_product_info(network=network, domain=domain,
 for(i in 1:nrow(prod_info)){
   # for(i in 1){
   
-    prodname_ms = glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
   
-    held_data = get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
   
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data = track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn = get_latest_product_version(prodname_ms=prodname_ms,
@@ -35,11 +35,11 @@ for(i in 1:nrow(prod_info)){
                                      drop=FALSE]
     
     if(! site_is_tracked(held_data, prodname_ms, site_name)){
-          held_data = insert_site_skeleton(held_data, prodname_ms, site_name,
+          held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                            site_components=avail_site_sets$component)
     }
     
-    held_data = track_new_site_components(held_data, prodname_ms, site_name,
+    held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                           avail_site_sets)
     if(is_ms_err(held_data)) next
     

--- a/src/lter/mcmurdo/derive.R
+++ b/src/lter/mcmurdo/derive.R
@@ -10,16 +10,16 @@ prod_info <- get_product_info(network = network,
 for(i in 1:nrow(prod_info)){
 # for(i in 2){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                              prodname_ms = prodname_ms,
                                              site_name = site_name,
                                              site_components = 'NA')

--- a/src/lter/mcmurdo/munge.R
+++ b/src/lter/mcmurdo/munge.R
@@ -45,6 +45,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/mcmurdo/munge.R
+++ b/src/lter/mcmurdo/munge.R
@@ -11,7 +11,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/mcmurdo/retrieve.R
+++ b/src/lter/mcmurdo/retrieve.R
@@ -8,12 +8,12 @@ prod_info <- get_product_info(network = network,
 # i=1
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms=prodname_ms,
@@ -34,11 +34,11 @@ for(i in 1:nrow(prod_info)){
             drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                 site_components=avail_site_sets$component)
         }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
             avail_site_sets)
         if(is_ms_err(held_data)) next
 

--- a/src/lter/niwot/derive.R
+++ b/src/lter/niwot/derive.R
@@ -9,18 +9,18 @@ prod_info <- get_product_info(network = network,
 # i=6
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
 
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
 
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                               prodname_ms = prodname_ms,
                                               site_name = site_name,
                                               site_components = 'NA')

--- a/src/lter/niwot/munge.R
+++ b/src/lter/niwot/munge.R
@@ -45,6 +45,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/niwot/munge.R
+++ b/src/lter/niwot/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/niwot/products.csv
+++ b/src/lter/niwot/products.csv
@@ -26,5 +26,3 @@ ms004,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux_ms007,NA
 ms006,stream_gauge_locations,NA,NA,ready,NA,NA
 ms007,precip_pchem_pflux,NA,NA,ready,NA,NA
 ms005,stream_flux_inst,NA,NA,ready,NA,NA
-ms000,ws_boundary,NA,NA,NA,precipitation__ms003,automated entry
-ms900,precipitation,NA,NA,NA,NA,automated entry

--- a/src/lter/niwot/retrieve.R
+++ b/src/lter/niwot/retrieve.R
@@ -8,13 +8,13 @@ prod_info <- get_product_info(network = network,
 # i=89
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
     
     latest_vsn <- get_latest_product_version(prodname_ms=prodname_ms,
@@ -37,12 +37,12 @@ for(i in 1:nrow(prod_info)){
                                              drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                               site_components=avail_site_sets$component)
 
         }
 
-    held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+    held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                            avail_site_sets)
 
     if(is_ms_err(held_data)) next

--- a/src/lter/plum/derive.R
+++ b/src/lter/plum/derive.R
@@ -9,16 +9,16 @@ prod_info <- get_product_info(network = network,
 # i=7
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                              prodname_ms = prodname_ms,
                                              site_name = site_name,
                                              site_components = 'NA')

--- a/src/lter/plum/munge.R
+++ b/src/lter/plum/munge.R
@@ -45,6 +45,7 @@ for(i in 1:nrow(prod_info)){
 
             if(is_ms_err(munge_rtn)){
 
+                logging::logerror(as.character(munge_rtn))
                 update_data_tracker_m(network = network,
                                       domain = domain,
                                       tracker_name = 'held_data',

--- a/src/lter/plum/munge.R
+++ b/src/lter/plum/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/plum/products.csv
+++ b/src/lter/plum/products.csv
@@ -136,5 +136,3 @@ ms002,stream_chemistry,NA,NA,ready,NA,NA,NA
 ms003,precipitation,NA,NA,ready,precip_pchem_pflux__ms008,NA,NA
 ms005,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms008,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
-ms000,ws_boundary,NA,NA,NA,precipitation__ms003,automated entry,NA
-ms900,precipitation,NA,NA,NA,NA,automated entry,NA

--- a/src/lter/plum/retrieve.R
+++ b/src/lter/plum/retrieve.R
@@ -8,12 +8,12 @@ prod_info <- get_product_info(network = network,
 # i=110
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network=network, domain=domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
-        held_data <- track_new_product(held_data, prodname_ms)
+        held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms=prodname_ms,
@@ -38,11 +38,11 @@ for(i in 1:nrow(prod_info)){
             drop=FALSE]
 
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                 site_components=avail_site_sets$component)
         }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
             avail_site_sets)
         if(is_ms_err(held_data)) next
 

--- a/src/lter/santa_barbara/derive.R
+++ b/src/lter/santa_barbara/derive.R
@@ -9,17 +9,17 @@ prod_info <- get_product_info(network = network,
 # i=4
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
 
         if(is_ms_prodcode(prodcode_from_prodname_ms(prodname_ms))){
-            held_data <- track_new_product(tracker = held_data,
+            held_data <<- track_new_product(tracker = held_data,
                                            prodname_ms = prodname_ms)
 
-            held_data <- insert_site_skeleton(tracker = held_data,
+            held_data <<- insert_site_skeleton(tracker = held_data,
                                               prodname_ms = prodname_ms,
                                               site_name = site_name,
                                               site_components = 'NA')

--- a/src/lter/santa_barbara/munge.R
+++ b/src/lter/santa_barbara/munge.R
@@ -56,6 +56,7 @@ for(i in 1:nrow(prod_info)){
 
         if(is_ms_err(munge_rtn)){
 
+            logging::logerror(as.character(munge_rtn))
             update_data_tracker_m(network = network,
                                   domain = domain,
                                   tracker_name = 'held_data',

--- a/src/lter/santa_barbara/munge.R
+++ b/src/lter/santa_barbara/munge.R
@@ -10,7 +10,7 @@ for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',

--- a/src/lter/santa_barbara/products.csv
+++ b/src/lter/santa_barbara/products.csv
@@ -63,6 +63,3 @@ ms004,precip_gauge_locations,NA,NA,ready,precipitation__ms003,NA,NA
 ms007,stream_gauge_locations,NA,NA,ready,NA,NA,NA
 ms003,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
 ms005,stream_flux_inst,NA,NA,ready,NA,NA,NA
-ms000,ws_boundary,NA,NA,NA,precip_pchem_pflux__ms003,automated entry,NA
-ms008,stream_chemistry,NA,NA,linked,NA,automated entry,NA
-ms900,precipitation,NA,NA,NA,NA,automated entry,NA

--- a/src/lter/santa_barbara/retrieve.R
+++ b/src/lter/santa_barbara/retrieve.R
@@ -8,12 +8,12 @@ prod_info = get_product_info(network = network,
 # i=41
 for(i in 1:nrow(prod_info)){
 
-    prodname_ms <- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
+    prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <- get_data_tracker(network = network, domain = domain)
+    held_data <<- get_data_tracker(network = network, domain = domain)
     
     if(! product_is_tracked(held_data, prodname_ms)){
-            held_data <- track_new_product(held_data, prodname_ms)
+            held_data <<- track_new_product(held_data, prodname_ms)
     }
 
     latest_vsn <- get_latest_product_version(prodname_ms = prodname_ms,
@@ -46,11 +46,11 @@ for(i in 1:nrow(prod_info)){
         
         if(! site_is_tracked(held_data, prodname_ms, site_name)){
 
-            held_data <- insert_site_skeleton(held_data, prodname_ms, site_name,
+            held_data <<- insert_site_skeleton(held_data, prodname_ms, site_name,
                                                      site_components=avail_site_sets$component)
             }
 
-        held_data <- track_new_site_components(held_data, prodname_ms, site_name,
+        held_data <<- track_new_site_components(held_data, prodname_ms, site_name,
                                                    avail_site_sets)
 
         if(is_ms_err(held_data)) next


### PR DESCRIPTION
@spencerrhea 
ms_delin no longer writes empty dirs when S or A inputs are given. also fixed an issue with remote config file updates. 

note two new dev helpers: invalidate_all sets all derive and munge kernels to "pending" in the data tracker. used when we're rebuilding from scratch.

drop_automated_entries removes rows with "automated entry" from products.csv files. we may want to store those remotely, but somehow account for the fact that we have different datasets built on each of our machines. this is a temp fix, but the full fix may involve storing all our data remotely, which we'll want to do eventually anyway.