### PR TITLE
synchronize_timestep and calc_inst_flux updated for full granularity of sensor data

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -39,6 +39,11 @@ suppressPackageStartupMessages({
     library(doParallel)
     library(googlesheets4)
     library(rgee) #requires geojsonio package
+
+
+    # install.packages("BiocManager") #required to get the IRanges package
+    # BiocManager::install("IRanges") #required for fuzzyjoin::difference_inner_join
+    library(fuzzyjoin)
 })
 
 options(dplyr.summarise.inform = FALSE)
@@ -198,7 +203,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=2
+dmnrow=11
 for(dmnrow in 1:nrow(network_domain)){
     # drop_automated_entries('.') #use with caution!
 

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -40,10 +40,10 @@ suppressPackageStartupMessages({
     library(googlesheets4)
     library(rgee) #requires geojsonio package
 
-
     # install.packages("BiocManager") #required to get the IRanges package
     # BiocManager::install("IRanges") #required for fuzzyjoin::difference_inner_join
     library(fuzzyjoin)
+
 })
 
 options(dplyr.summarise.inform = FALSE)
@@ -203,7 +203,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-dmnrow=11
+# dmnrow=2
 for(dmnrow in 1:nrow(network_domain)){
     # drop_automated_entries('.') #use with caution!
 

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -203,7 +203,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=2
+# dmnrow=12
 for(dmnrow in 1:nrow(network_domain)){
     # drop_automated_entries('.') #use with caution!
 

--- a/src/czo/boulder/processing_kernels.R
+++ b/src/czo/boulder/processing_kernels.R
@@ -166,9 +166,7 @@ process_1_2918 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -241,9 +239,7 @@ process_1_2919 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -406,9 +402,7 @@ process_1_2785 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -450,9 +444,7 @@ process_1_7241 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -606,9 +598,7 @@ process_1_3639 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -650,9 +640,7 @@ process_1_2435 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -694,9 +682,7 @@ process_1_2888 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -738,9 +724,7 @@ process_1_2889 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/czo/catalina_jemez/processing_kernels.R
+++ b/src/czo/catalina_jemez/processing_kernels.R
@@ -265,9 +265,7 @@ process_1_2504 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -317,9 +315,7 @@ process_1_6686 <- function(network, domain, prodname_ms, site_name, component) {
                                domain = domain,
                                prodname_ms = prodname_ms)
 
-        d <- synchronize_timestep(d,
-                                  desired_interval = '1 day', #set to '15 min' when we have server
-                                  impute_limit = 30)
+        d <- synchronize_timestep(d)
 
         d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -513,9 +509,7 @@ process_1_4135 <- function(network, domain, prodname_ms, site_name, component) {
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     #
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     #
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -574,9 +568,7 @@ process_1_2532 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -763,9 +755,7 @@ process_1_5491 <- function(network, domain, prodname_ms, site_name, component) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/czo/network_helpers.R
+++ b/src/czo/network_helpers.R
@@ -218,9 +218,7 @@ pull_cdnr_discharge <- function(network, domain, prodname_ms, sites) {
                                domain = domain,
                                prodname_ms = prodname_ms)
 
-        d <- synchronize_timestep(d,
-                                  desired_interval = '1 day', #set to '15 min' when we have server
-                                  impute_limit = 30)
+        d <- synchronize_timestep(d)
 
         d <- apply_detection_limit_t(d, network, domain, prodname_ms, ignore_pred=TRUE)
 

--- a/src/dev/dev_helpers.R
+++ b/src/dev/dev_helpers.R
@@ -613,3 +613,39 @@ drop_automated_entries <- function(path = '.'){
                 .open = '<<',
                 .close = '>>'))
 }
+
+dy_examine <- function(d, ...){
+
+    #for quickly plotting time series in order to zoom in on points, so you
+    #don't have to make an xts object and all that crap
+
+    #usage example: dy_examine(d, IS_discharge, GN_NH4_N)
+
+    dots = match.call(expand.dots = FALSE)$...
+    arg_names = vapply(dots, as.character, '')
+
+    d = xts::xts(d[, arg_names],
+                 order.by = d$datetime,
+                 tzone = lubridate::tz(d$datetime[1]))
+
+    dygraphs::dygraph(d) %>%
+        dygraphs::dyOptions(
+            useDataTimezone = TRUE,
+            # fillGraph = TRUE,
+            retainDateWindow = TRUE,
+            labelsKMB = TRUE,
+            # stackedGraph = TRUE,
+
+            # #if precip panels are separated, use these specifications
+            # fillAlpha = 1,
+            # colors = raincolors[1],
+            # strokeWidth = 3,
+            # plotter = hyetograph_js,
+
+            #if not showing points, use these
+            drawPoints = FALSE,
+            strokeWidth = 1,
+            fillAlpha = 0.4,
+            colors = rainbow(length(arg_names)),
+            drawGapEdgePoints = TRUE)
+}

--- a/src/dev/dev_helpers.R
+++ b/src/dev/dev_helpers.R
@@ -614,38 +614,77 @@ drop_automated_entries <- function(path = '.'){
                 .close = '>>'))
 }
 
-dy_examine <- function(d, ...){
+dy_examine <- function(d, shape = 'long', site, ...){
+
+    #TODO: to make this show gaps properly, we could use the new populate_implicit_NAs function
 
     #for quickly plotting time series in order to zoom in on points, so you
     #don't have to make an xts object and all that crap
 
-    #usage example: dy_examine(d, IS_discharge, GN_NH4_N)
+    #d is either a standard ms tibble, or a tibble/df with datetime, site_name,
+    #   and var columns.
+    #shape is either 'long' (standard ms tibble) or 'wide'
+    #site is a single site name, present in d$site_name
+    #... = variable names
+
+    #usage example: dy_examine(d, 'long', 'upper_ipswich', IS_discharge, GN_NH4_N)
+    #(nonstandard evaluation works for anything passed to ...)
 
     dots = match.call(expand.dots = FALSE)$...
     arg_names = vapply(dots, as.character, '')
 
-    d = xts::xts(d[, arg_names],
-                 order.by = d$datetime,
-                 tzone = lubridate::tz(d$datetime[1]))
+    d = filter(d, site_name == !!site)
+
+
+    if(shape == 'wide'){
+
+        if(any(! arg_names %in% colnames(d))){
+            v = colnames(select(d, -site_name, -datetime))
+            stop(glue('no data to plot. available variables for {s} are: {vv}',
+                      s = site,
+                      vv = paste(v, collapse = ", ")))
+        }
+
+        d = d[, arg_names]
+
+    } else if(shape == 'long'){
+
+        if(any(! arg_names %in% unique(d$var))){
+            stop(glue('no data to plot. available variables for {s} are: {vv}',
+                      s = site,
+                      vv = paste(unique(d$var), collapse = ", ")))
+        }
+
+        d = select(d, datetime, site_name, var, val)
+        d = d %>%
+            filter(var %in% arg_names) %>%
+            pivot_wider(names_from = 'var',
+                        values_from = 'val')
+
+    } else {
+        stop('shape must be "wide" or "long"')
+    }
+
+    d = xts::xts(select(d, -datetime, -site_name),
+             order.by = d$datetime,
+             tzone = lubridate::tz(d$datetime[1]))
 
     dygraphs::dygraph(d) %>%
         dygraphs::dyOptions(
             useDataTimezone = TRUE,
-            # fillGraph = TRUE,
             retainDateWindow = TRUE,
             labelsKMB = TRUE,
-            # stackedGraph = TRUE,
-
-            # #if precip panels are separated, use these specifications
-            # fillAlpha = 1,
-            # colors = raincolors[1],
-            # strokeWidth = 3,
-            # plotter = hyetograph_js,
-
-            #if not showing points, use these
+            connectSeparatedPoints = FALSE,
             drawPoints = FALSE,
             strokeWidth = 1,
             fillAlpha = 0.4,
             colors = rainbow(length(arg_names)),
             drawGapEdgePoints = TRUE)
+
+            # fillAlpha = 1,
+            # colors = raincolors[1],
+            # strokeWidth = 3,
+            # plotter = hyetograph_js,
+            # stackedGraph = TRUE,
+            # fillGraph = TRUE,
 }

--- a/src/dev/efficiency_comparisons.R
+++ b/src/dev/efficiency_comparisons.R
@@ -72,12 +72,8 @@ compare_efficiency(ff, gg, 10, 1e5,
                    outfile='plots/efficiency_comparisons/Xleast_NA_rowwise.png')
 
 #synchronize_timestep ####
-ff = expression(synchronize_timestep(ms_df = d[1:s,],
-                                     desired_interval = '1 day',
-                                     impute_limit = 30))
-gg = expression(synchronize_timestep(ms_df = dd[1:s,],
-                                     desired_interval = '1 day',
-                                     impute_limit = 30))
+ff = expression(synchronize_timestep(ms_df = d[1:s,])
+gg = expression(synchronize_timestep(ms_df = dd[1:s,])
 compare_efficiency(ff, gg, 10, 1e6,
                    outfile='plots/efficiency_comparisons/synchronize_timestep.png')
 

--- a/src/dev/func_code_templates.R
+++ b/src/dev/func_code_templates.R
@@ -96,14 +96,10 @@ process_1_XXX <- function(network, domain, prodname_ms, site_name,
     # intv <- ifelse(grepl('precip', prodname_ms),
     #                '1 day',
     #                '1 hour')
-    # d <- ue(synchronize_timestep(ms_df = d,
-    #                              desired_interval = intv,
-    #                              impute_limit = 30))
+    # d <- ue(synchronize_timestep(ms_df = d)
 
     #constant interval
-    d <- ue(synchronize_timestep(ms_df = d,
-                                 desired_interval = '15 min',
-                                 impute_limit = 30))
+    d <- ue(synchronize_timestep(ms_df = d)
 
     return(d)
 }

--- a/src/dev/test/investigating_Si_discrepancy.R
+++ b/src/dev/test/investigating_Si_discrepancy.R
@@ -1,0 +1,29 @@
+library(feather)
+library(readr)
+library(tidyverse)
+
+df =read_feather('macrosheds/data_acquisition/data/lter/niwot/derived/stream_flux_inst__ms005/ALBION.feather')
+pf =read_feather('macrosheds/portal/data/niwot/stream_flux_inst/ALBION.feather')
+identical(df, pf)
+
+ra=read_csv('macrosheds/data_acquisition/data/lter/niwot/raw/stream_chemistry__103/sitename_NA/albisolu.nc.data.csv')
+dplyr::filter(ra, date > as.Date('2009-06-24'), date < as.Date('2009-06-28'))
+fivenum(as.numeric(ra$Si), na.rm=T)
+
+apr25Si = 75.8 / 1000000  * 28.086 * 1000
+
+q=read_csv('macrosheds/data_acquisition/data/lter/niwot/raw/discharge__102/sitename_NA/albdisch.nc.data.csv')
+dplyr::filter(q, date > as.Date('2009-06-24'), date < as.Date('2009-06-26'))
+
+apr25q = 42725 * 1000 / 86400
+
+#mg/L       L/s
+flux = apr25Si * apr25q
+
+#kg/d
+flux = flux / 1000000 * 60 * 60 * 24
+
+#kg/ha/d
+flux / 715
+#kg/ha/yr
+flux / 715 * 365

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -5429,7 +5429,9 @@ read_precip_quickref <- function(network,
     # return(quickref)
 }
 
-synchronize_timestep <- function(d, desired_interval, impute_limit = 30){
+synchronize_timestep <- function(d,
+                                 desired_interval,
+                                 impute_limit = 30){
 
     #d is a df/tibble with columns: datetime (POSIXct), site_name, var, val, ms_status
     #desired_interval is a character string that can be parsed by the "by"
@@ -8178,7 +8180,10 @@ catalogue_held_data <- function(network_domain, site_data){
 
     #tabulates:
     # + total nonspatial observations for the portal landing page
-    # +
+    # + informational catalog for all variables
+    # + informational catalog for all sites
+    # + informational catalog for each individual variable
+    # + informational catalog for each individual site
 
     nobs_nonspatial <- 0
     # site_display <- tibble()
@@ -8351,9 +8356,10 @@ catalogue_held_data <- function(network_domain, site_data){
             Unit = first(Unit)) %>%
         ungroup() %>%
         mutate(MeanObsPerSite = round(Observations / Sites, 0),
-               Availability = 'feature not yet built') %>%
-        select(VariableName, VariableCode, Unit, Observations, Sites,
-               MeanObsPerSite, FirstRecordUTC, LastRecordUTC, Availability)
+               Availability = paste0("<button type='button' id='", VariableCode, "'>view</button>")) %>%
+               # Availability = paste0("<a href='?", VariableCode, "'>view</a>")) %>%
+        select(Availability, VariableName, VariableCode, Unit, Observations, Sites,
+               MeanObsPerSite, FirstRecordUTC, LastRecordUTC)
 
     readr::write_csv(x = all_variable_display,
                      file = 'general/catalog_files/all_variables.csv')
@@ -8423,20 +8429,23 @@ catalogue_held_data <- function(network_domain, site_data){
         ungroup() %>%
         mutate(MeanObsPerVar = round(Observations / Variables, 0),
                ExternalLink = 'feature not yet built',
-               Availability = 'feature not yet built') %>%
+               Availability = paste0("<button type='button' id='",
+                                     network, '_', domain, '_', site_name,
+                                     "'>view</button>")) %>%
         left_join(all_site_breakdown,
                   by = c('network', 'domain', 'site_name')) %>%
-        select(Network = pretty_network,
+        select(Availability,
+               Network = pretty_network,
                Domain = pretty_domain,
-               SiteName = full_name,
                SiteCode = site_name,
+               SiteName = full_name,
                StreamName = stream,
                Latitude = latitude,
                Longitude = longitude,
                SiteType = site_type,
                AreaHectares = ws_area_ha,
                Observations, Variables, FirstRecordUTC, LastRecordUTC,
-               Availability, ExternalLink)
+               ExternalLink)
 
     readr::write_csv(x = all_site_display,
                      file = 'general/catalog_files/all_sites.csv')

--- a/src/lter/arctic/domain_helpers.R
+++ b/src/lter/arctic/domain_helpers.R
@@ -104,9 +104,7 @@ munge_discharge <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -195,9 +193,7 @@ munge_discharge_temp <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -260,9 +256,7 @@ munge_toolik <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -326,9 +320,7 @@ munge_toolik_2 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/arctic/domain_helpers.R
+++ b/src/lter/arctic/domain_helpers.R
@@ -105,7 +105,7 @@ munge_discharge <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -196,7 +196,7 @@ munge_discharge_temp <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -261,7 +261,7 @@ munge_toolik <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -327,7 +327,7 @@ munge_toolik_2 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)

--- a/src/lter/arctic/processing_kernels.R
+++ b/src/lter/arctic/processing_kernels.R
@@ -175,9 +175,7 @@ process_1_10601 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -244,9 +242,7 @@ process_1_20118 <- function(network, domain, prodname_ms, site_name,
                          domain = domain,
                          prodname_ms = prodname_ms)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '15 min',
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -478,9 +474,7 @@ process_1_10303 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     remove_1_vars <- d %>%
         group_by(site_name, var) %>%
@@ -531,9 +525,7 @@ process_1_1489 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -608,9 +600,7 @@ process_1_20120 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -754,9 +744,7 @@ process_1_10591 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -807,9 +795,7 @@ process_1_20103 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -860,9 +846,7 @@ process_1_20111 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -914,9 +898,7 @@ process_1_20112 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/arctic/processing_kernels.R
+++ b/src/lter/arctic/processing_kernels.R
@@ -176,7 +176,7 @@ process_1_10601 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -245,7 +245,7 @@ process_1_20118 <- function(network, domain, prodname_ms, site_name,
                          prodname_ms = prodname_ms)
 
   d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
+                            desired_interval = '15 min',
                             impute_limit = 30)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -479,7 +479,7 @@ process_1_10303 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     remove_1_vars <- d %>%
@@ -532,7 +532,7 @@ process_1_1489 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -609,7 +609,7 @@ process_1_20120 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -755,7 +755,7 @@ process_1_10591 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -808,7 +808,7 @@ process_1_20103 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -861,7 +861,7 @@ process_1_20111 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
@@ -915,7 +915,7 @@ process_1_20112 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)

--- a/src/lter/baltimore/processing_kernels.R
+++ b/src/lter/baltimore/processing_kernels.R
@@ -105,9 +105,7 @@ process_1_700 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -147,9 +145,7 @@ process_1_900 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -191,9 +187,7 @@ process_1_800 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -258,9 +252,7 @@ process_1_3110 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/bonanza/processing_kernels.R
+++ b/src/lter/bonanza/processing_kernels.R
@@ -134,9 +134,7 @@ process_1_152 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 }
@@ -171,9 +169,7 @@ process_1_142 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 }
@@ -209,9 +205,7 @@ process_1_159 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 }
@@ -253,9 +247,7 @@ process_1_167 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 }
@@ -304,9 +296,7 @@ process_1_157 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 }

--- a/src/lter/coweeta/processing_kernels.R
+++ b/src/lter/coweeta/processing_kernels.R
@@ -205,9 +205,7 @@ process_1_7 <- function(network, domain, prodname_ms, site_name,
   d <- d %>%
     mutate(val = val*1000)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -268,9 +266,7 @@ process_1_8 <- function(network, domain, prodname_ms, site_name,
   d <- d %>%
     mutate(val = val*1000)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -331,9 +327,7 @@ process_1_9 <- function(network, domain, prodname_ms, site_name,
   d <- d %>%
     mutate(val = val*1000)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -394,9 +388,7 @@ process_1_10 <- function(network, domain, prodname_ms, site_name,
   d <- d %>%
     mutate(val = val*1000)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -502,9 +494,7 @@ process_1_50 <- function(network, domain, prodname_ms, site_name,
                                            TN = 'mg/l', SRP = 'mg/l',
                                            TP = 'mg/l'))
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -549,9 +539,7 @@ process_1_51 <- function(network, domain, prodname_ms, site_name,
                          domain = domain,
                          prodname_ms = prodname_ms)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -608,9 +596,7 @@ process_1_20 <- function(network, domain, prodname_ms, site_name,
                          domain = domain,
                          prodname_ms = prodname_ms)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -723,9 +709,7 @@ process_1_43 <- function(network, domain, prodname_ms, site_name,
                                            TPsN = 'mg/l', SRP = 'mg/l',
                                            TPP = 'mg/l'))
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -768,9 +752,7 @@ process_1_4 <- function(network, domain, prodname_ms, site_name,
                          domain = domain,
                          prodname_ms = prodname_ms)
 
-  d <- synchronize_timestep(d,
-                            desired_interval = '1 day', #set to '15 min' when we have server
-                            impute_limit = 30)
+  d <- synchronize_timestep(d)
 
   d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/hbef/processing_kernels.R
+++ b/src/lter/hbef/processing_kernels.R
@@ -168,8 +168,7 @@ process_1_1 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+                              desired_interval = '15 min')
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -211,8 +210,7 @@ process_1_13 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+                              desired_interval = '1 day')
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -278,8 +276,7 @@ process_1_208 <- function(network, domain, prodname_ms, site_name,
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+                              desired_interval = '1 day')
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/hjandrews/processing_kernels.R
+++ b/src/lter/hjandrews/processing_kernels.R
@@ -247,9 +247,7 @@ process_1_4341 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -314,9 +312,7 @@ process_1_5482 <- function(network, domain, prodname_ms, site_name,
                                domain = domain,
                                prodname_ms = prodname_ms)
 
-        d <- synchronize_timestep(d,
-                                  desired_interval = '1 day', #set to '15 min' when we have server
-                                  impute_limit = 30)
+        d <- synchronize_timestep(d)
 
         d <- apply_detection_limit_t(d, network, domain, prodname_ms)
     }
@@ -376,9 +372,7 @@ process_1_4021 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -450,9 +444,7 @@ process_1_4022 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/konza/processing_kernels.R
+++ b/src/lter/konza/processing_kernels.R
@@ -205,9 +205,7 @@ process_1_7 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -268,9 +266,7 @@ process_1_8 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -331,9 +327,7 @@ process_1_9 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -394,9 +388,7 @@ process_1_10 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -505,9 +497,7 @@ process_1_50 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d,
                                  network = network,
@@ -554,9 +544,7 @@ process_1_51 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -613,9 +601,7 @@ process_1_20 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -732,9 +718,7 @@ process_1_43 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -777,9 +761,7 @@ process_1_4 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/luquillo/processing_kernels.R
+++ b/src/lter/luquillo/processing_kernels.R
@@ -103,9 +103,7 @@ process_1_20 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
   
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
   
@@ -180,9 +178,7 @@ process_1_156 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
     

--- a/src/lter/mcmurdo/domain_helpers.R
+++ b/src/lter/mcmurdo/domain_helpers.R
@@ -140,9 +140,7 @@ munge_mcmurdo_discharge <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }

--- a/src/lter/mcmurdo/processing_kernels.R
+++ b/src/lter/mcmurdo/processing_kernels.R
@@ -177,9 +177,7 @@ process_1_9002 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -260,9 +258,7 @@ process_1_9003 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -343,9 +339,7 @@ process_1_9007 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -434,9 +428,7 @@ process_1_9009 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -542,9 +534,7 @@ process_1_9022 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -627,9 +617,7 @@ process_1_9021 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -723,9 +711,7 @@ process_1_9029 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
 }
@@ -785,9 +771,7 @@ process_1_24 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
     
@@ -870,9 +854,7 @@ process_1_20 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
     
@@ -955,9 +937,7 @@ process_1_21 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
     
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)

--- a/src/lter/niwot/munge.R
+++ b/src/lter/niwot/munge.R
@@ -1,26 +1,27 @@
 loginfo('Beginning munge', logger=logger_module)
 
 prod_info <- get_product_info(network = network,
-                             domain = domain,
-                             status_level = 'munge',
-                             get_statuses = 'ready')
+                              domain = domain,
+                              status_level = 'munge',
+                              get_statuses = 'ready')
 
-# i=3
 for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
 
-    held_data <<- get_data_tracker(network=network, domain=domain)
+    held_data <<- get_data_tracker(network = network,
+                                   domain = domain)
 
     if(! product_is_tracked(held_data, prodname_ms)){
         logwarn(glue('Product {p} is not yet tracked. Retrieve ',
-                     'it before munging it.', p=prodname_ms), logger=logger_module)
+                     'it before munging it.',
+                     p = prodname_ms),
+                logger = logger_module)
         next
     }
 
     sites <- names(held_data[[prodname_ms]])
 
-    # j = 1
     for(j in 1:length(sites)){
 
         site_name <- sites[j]
@@ -30,18 +31,22 @@ for(i in 1:nrow(prod_info)){
                                          site_name = site_name)
         if(munge_status == 'ok'){
               loginfo(glue('Nothing to do for {s} {p}',
-                       s=site_name, p=prodname_ms), logger=logger_module)
+                           s = site_name,
+                           p = prodname_ms),
+                      logger = logger_module)
             next
         } else {
             loginfo(glue('Munging {s} {p}',
-                         s=site_name, p=prodname_ms), logger=logger_module)
+                         s = site_name,
+                         p = prodname_ms),
+                    logger = logger_module)
         }
 
         munge_rtn <- munge_by_site(network = network,
-                                  domain = domain,
-                                  site_name = site_name,
-                                  prodname_ms = prodname_ms,
-                                  tracker = held_data)
+                                   domain = domain,
+                                   site_name = site_name,
+                                   prodname_ms = prodname_ms,
+                                   tracker = held_data)
 
         if(is_ms_err(munge_rtn)){
 
@@ -70,4 +75,4 @@ for(i in 1:nrow(prod_info)){
 }
 
 loginfo('Munging complete for all sites and products',
-        logger=logger_module)
+        logger = logger_module)

--- a/src/lter/niwot/processing_kernels.R
+++ b/src/lter/niwot/processing_kernels.R
@@ -186,9 +186,7 @@ process_1_213 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -300,9 +298,7 @@ process_1_103 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -415,9 +411,7 @@ process_1_107 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -531,9 +525,7 @@ process_1_108 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -646,9 +638,7 @@ process_1_109 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -761,9 +751,7 @@ process_1_110 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -875,9 +863,7 @@ process_1_112 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -989,9 +975,7 @@ process_1_113 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1104,9 +1088,7 @@ process_1_9 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1219,9 +1201,7 @@ process_1_160 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1333,9 +1313,7 @@ process_1_162 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1448,9 +1426,7 @@ process_1_163 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1497,9 +1473,7 @@ process_1_102 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1539,9 +1513,7 @@ process_1_111 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1588,9 +1560,7 @@ process_1_74 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1652,9 +1622,7 @@ process_1_105 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1696,9 +1664,7 @@ process_1_416 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1738,9 +1704,7 @@ process_1_414 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1783,9 +1747,7 @@ process_1_415 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/plum/domain_helpers.R
+++ b/src/lter/plum/domain_helpers.R
@@ -92,9 +92,7 @@ munge_plum_combined <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -156,9 +154,7 @@ munge_plum_temp_q <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -209,9 +205,7 @@ munge_plum_temp_cond <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -262,9 +256,7 @@ munge_plum_temp_cond_cart <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -315,9 +307,7 @@ munge_plum_temp_do <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms) 
     
@@ -368,9 +358,7 @@ munge_precip <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -412,9 +400,7 @@ munge_precip_alt <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     # 
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     # 
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/plum/munge.R
+++ b/src/lter/plum/munge.R
@@ -38,10 +38,10 @@ for(i in 1:nrow(prod_info)){
         }
 
             munge_rtn <- munge_time_component(network = network,
-                                             domain = domain,
-                                             site_name = site_name,
-                                             prodname_ms = prodname_ms,
-                                             tracker = held_data)
+                                              domain = domain,
+                                              site_name = site_name,
+                                              prodname_ms = prodname_ms,
+                                              tracker = held_data)
 
             if(is_ms_err(munge_rtn)){
 

--- a/src/lter/plum/processing_kernels.R
+++ b/src/lter/plum/processing_kernels.R
@@ -1167,10 +1167,14 @@ process_2_ms001 <- function(network, domain, prodname_ms) {
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
+                              desired_interval = '15 min',
                               impute_limit = 30)
 
-    d <- apply_detection_limit_t(d, network, domain, prodname_ms, ignore_pred = TRUE)
+    d <- apply_detection_limit_t(X = d,
+                                 network = network,
+                                 domain = domain,
+                                 prodname_ms = prodname_ms,
+                                 ignore_pred = TRUE)
 
     dir <- glue('data/{n}/{d}/derived/{p}',
                 n = network,
@@ -1258,8 +1262,7 @@ process_2_ms002 <- function(network, domain, prodname_ms) {
                            prodname_ms = prodname_ms)
 
     d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+                              desired_interval = '15 min')
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms, ignore_pred = TRUE)
 

--- a/src/lter/plum/processing_kernels.R
+++ b/src/lter/plum/processing_kernels.R
@@ -1261,8 +1261,7 @@ process_2_ms002 <- function(network, domain, prodname_ms) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min')
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms, ignore_pred = TRUE)
 

--- a/src/lter/plum/processing_kernels.R
+++ b/src/lter/plum/processing_kernels.R
@@ -616,9 +616,7 @@ process_1_155 <- function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     #
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     #
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -756,9 +754,7 @@ process_1_393 <-  function(network, domain, prodname_ms, site_name,
     #                        domain = domain,
     #                        prodname_ms = prodname_ms)
     #
-    # d <- synchronize_timestep(d,
-    #                           desired_interval = '1 day', #set to '15 min' when we have server
-    #                           impute_limit = 30)
+    # d <- synchronize_timestep(d)
     #
     # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -1166,9 +1162,7 @@ process_2_ms001 <- function(network, domain, prodname_ms) {
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '15 min',
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(X = d,
                                  network = network,
@@ -1319,9 +1313,7 @@ process_2_ms003 <- function(network, domain, prodname_ms){
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms, ignore_pred = TRUE)
 

--- a/src/lter/santa_barbara/domain_helpers.R
+++ b/src/lter/santa_barbara/domain_helpers.R
@@ -71,9 +71,7 @@ munge_santa_barbara_precip <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 
@@ -113,9 +111,7 @@ munge_santa_barbara_discharge <- function(network, domain, prodname_ms, site_nam
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/lter/santa_barbara/processing_kernels.R
+++ b/src/lter/santa_barbara/processing_kernels.R
@@ -455,9 +455,7 @@ process_1_6 <- function(network, domain, prodname_ms, site_name,
                            domain = domain,
                            prodname_ms = prodname_ms)
 
-    d <- synchronize_timestep(d,
-                              desired_interval = '1 day', #set to '15 min' when we have server
-                              impute_limit = 30)
+    d <- synchronize_timestep(d)
 
     d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 

--- a/src/neon/neon/processing_kernels.R
+++ b/src/neon/neon/processing_kernels.R
@@ -479,9 +479,7 @@ process_1_DP1.20053 <- function(network, domain, prodname_ms, site_name,
     # #                        domain = domain,
     # #                        prodname_ms = prodname_ms)
     # #
-    # # d <- synchronize_timestep(d,
-    # #                           desired_interval = '15 min',
-    # #                           impute_limit = 30)
+    # # d <- synchronize_timestep(d)
     # #
     # # d <- apply_detection_limit_t(d, network, domain, prodname_ms)
     #

--- a/src/neon/neon/processing_kernels.R
+++ b/src/neon/neon/processing_kernels.R
@@ -527,8 +527,7 @@ process_1_DP1.00004 <- function(network, domain, prodname_ms, site_name,
             ms_status)
 
     out_sub <- synchronize_timestep(ms_df = out_sub,
-                                    desired_interval = '15 min',
-                                    impute_limit = 30)
+                                    desired_interval = '15 min')
 
     return(out_sub)
 }

--- a/src/neon/network_helpers.R
+++ b/src/neon/network_helpers.R
@@ -114,8 +114,7 @@ munge_neon_site <- function(domain, site_name, prodname_ms, tracker, silent=TRUE
             }
 
             d <- synchronize_timestep(d,
-                                      desired_interval = '1 day',
-                                      impute_limit = 30)
+                                      desired_interval = '1 day')
 
             d <- apply_detection_limit_t(d, network, domain, prodname_ms)
 


### PR DESCRIPTION
@spencer
- calc_inst_flux now creates separate ms_status and ms_interp columns for each variable when it pivots wider
- synchronize_timestep now splits the dataset by site and variable, then rounds datetimes, summarizes duplicates, populates implicit NAs, interpolates, and recombines.
- synchronize_timestep takes no arguments now. Timestep and maxgap (for interpolation) are determined automatically. all calls have been updated.
- BTW: I learned how to recursively make multiline text substitutions. Next time you find yourself needing to modify 100 kernels by hand, hit me up!
- REMAINING ISSUE: rounding of datetimes can shift real timestamps by up to 12 hours (for daily) and up to 7.5 minutes (for 15m). 
- New dev helper: dy_examine, for quickly plotting a dygraph of one or more series in a dataset (in either long or wide format)