### PR TITLE
delineation overhaul, precip flux fix

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -220,7 +220,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-dmnrow=14
+# dmnrow=12
 for(dmnrow in 1:nrow(network_domain)){
 # for(dmnrow in 9){
     # drop_automated_entries('.') #use with caution!
@@ -233,7 +233,7 @@ for(dmnrow in 1:nrow(network_domain)){
     # owrite_tracker(network, domain)
     # held_data = invalidate_tracked_data(network, domain, 'derive')
     # owrite_tracker(network, domain)
-    # held_data = invalidate_tracked_data(network, domain, 'munge', 'stream_chemistry__10303')
+    # held_data = invalidate_tracked_data(network, domain, 'munge', 'ws_boundary__3239')
     # owrite_tracker(network, domain)
     # held_data = invalidate_tracked_data(network, domain, 'derive', 'precip_pchem_pflux__ms004')
     # owrite_tracker(network, domain)

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -220,7 +220,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=4
+dmnrow=14
 for(dmnrow in 1:nrow(network_domain)){
 # for(dmnrow in 9){
     # drop_automated_entries('.') #use with caution!

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -40,6 +40,7 @@ suppressPackageStartupMessages({
     library(doFuture)
     library(googlesheets4)
     library(rgee) #requires geojsonio package
+    library(osmdata)
 
     # install.packages("BiocManager") #required to get the IRanges package
     # BiocManager::install("IRanges") #required for fuzzyjoin::difference_inner_join

--- a/src/czo/calhoun/products.csv
+++ b/src/czo/calhoun/products.csv
@@ -1,8 +1,8 @@
 prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,hydroshare_id,component
 6421,precipitation,ready,ready,NA,precip_pchem_pflux__ms005,NA,9b2a6c9e66c84380b0bfe34e435a0e0f,!!SEARCH(CONTAINS(.csv))
 6470,discharge,ready,ready,NA,stream_flux_inst__ms004,modern discharge,ad719c838a7b44e8bbacb33d2c4dd95f,!!SEARCH(CONTAINS(.csv))
-4680,precipitation,pending,ready,NA,NA,historical precip,4a30c526f14141bfbd4b496d348fbd20,calhoun-hydrology-1949-1962.zip
-4680,discharge,pending,ready,NA,NA,historical discharge,4a30c526f14141bfbd4b496d348fbd20,calhoun-hydrology-1949-1962.zip
+4680,precipitation,pending,pending,NA,NA,historical precip,4a30c526f14141bfbd4b496d348fbd20,calhoun-hydrology-1949-1962.zip
+4680,discharge,pending,pending,NA,NA,historical discharge,4a30c526f14141bfbd4b496d348fbd20,calhoun-hydrology-1949-1962.zip
 2851,stream_chemistry,ready,ready,NA,stream_flux_inst__ms004,NA,63cd313bd15b4b77b05b8f34ec9388ee,!!SEARCH(EXCLUDE(water-grab-samples.xlsx|ReadMe.md))
 ms001,precip_gauge_locations,NA,NA,ready,NA,NA,NA,NA
 ms002,stream_gauge_locations,NA,NA,ready,NA,NA,NA,NA

--- a/src/global/munge_engines.R
+++ b/src/global/munge_engines.R
@@ -41,7 +41,10 @@ munge_by_site <- function(network, domain, site_name, prodname_ms, tracker,
                                            component = in_comp)))
 
         if(! is_ms_err(out_comp) && ! is_ms_exception(out_comp)){
-            out = bind_rows(out, out_comp)
+
+            # out = bind_rows(out, out_comp)
+            out <- data.table::rbindlist(list(out, out_comp)) %>%
+                as_tibble()
         }
     }
 
@@ -144,7 +147,11 @@ munge_combined <- function(network, domain, site_name, prodname_ms, tracker,
         #IS IT POSSIBLE TO return(next)?
 
         if(! is_ms_err(out_comp) && ! is_ms_exception(out_comp)){
-            out <- bind_rows(out, out_comp)
+
+            #internal dplyr error encountered here for konza -> precip_gauge_locations__230
+            # out <- bind_rows_sf(out, as_tibble(out_comp))
+            out <- data.table::rbindlist(list(out, out_comp)) %>%
+                as_tibble()
         }
     }
 

--- a/src/lter/hjandrews/processing_kernels.R
+++ b/src/lter/hjandrews/processing_kernels.R
@@ -505,10 +505,13 @@ process_1_3239 <- function(network, domain, prodname_ms, site_name,
                 site_name = paste0('GSWS', site_name),
                 site_name = ifelse(site_name == 'GSWSMACK',
                                    'GSMACK',
-                                   site_name),
-                site_name = ifelse(site_name == 'GSWS04',
-                                   'GSLOOK',
                                    site_name)) %>%
+                #GSWS04 is GSLOOK, but that shapefile is missing subwatersheds,
+                #   so we're going to drop it here and delineate it ourselves
+                # site_name = ifelse(site_name == 'GSWS04',
+                #                    'GSLOOK',
+                #                    site_name)) %>%
+            filter(site_name != 'GSWS04') %>%
             sf::st_transform(projstring) %>%
             arrange(site_name)
     }

--- a/src/lter/konza/processing_kernels.R
+++ b/src/lter/konza/processing_kernels.R
@@ -176,14 +176,12 @@ process_1_7 <- function(network, domain, prodname_ms, site_name,
 
     d <- ms_cast_and_reflag(d,
                             varflag_col_pattern = NA,
-                            variable_flags_to_drop = NA,
-                            variable_flags_clean = NA,
-                            summary_flags_dirty = list('QUAL_FLAG' = 1,
-                                                       'MAINTENANCE_FLAG' = 1,
-                                                       'INCOMPLETE_FLAG' = 1),
-                            summary_flags_to_drop = list('QUAL_FLAG' = 6,
-                                                         'MAINTENANCE_FLAG' = 6,
-                                                         'INCOMPLETE_FLAG' = 6))
+                            summary_flags_to_drop = list('QUAL_FLAG' = '1',
+                                                         'MAINTENANCE_FLAG' = '1',
+                                                         'INCOMPLETE_FLAG' = '1'),
+                            summary_flags_clean = list('QUAL_FLAG' = c('0', '.'),
+                                                       'MAINTENANCE_FLAG' = c('0', '.'),
+                                                       'INCOMPLETE_FLAG' = c('0', '.')))
 
     # Convert from cm/s to liters/s
     d <- d %>%
@@ -237,14 +235,12 @@ process_1_8 <- function(network, domain, prodname_ms, site_name,
 
     d <- ms_cast_and_reflag(d,
                             varflag_col_pattern = NA,
-                            variable_flags_to_drop = NA,
-                            variable_flags_clean = NA,
-                            summary_flags_dirty = list('QUAL_FLAG' = 1,
-                                                       'MAINTENANCE_FLAG' = 1,
-                                                       'INCOMPLETE_FLAG' = 1),
-                            summary_flags_to_drop = list('QUAL_FLAG' = 6,
-                                                         'MAINTENANCE_FLAG' = 6,
-                                                         'INCOMPLETE_FLAG' = 6))
+                            summary_flags_to_drop = list('QUAL_FLAG' = '1',
+                                                         'MAINTENANCE_FLAG' = '1',
+                                                         'INCOMPLETE_FLAG' = '1'),
+                            summary_flags_clean = list('QUAL_FLAG' = c('0', '.'),
+                                                       'MAINTENANCE_FLAG' = c('0', '.'),
+                                                       'INCOMPLETE_FLAG' = c('0', '.')))
 
     # Convert from cm/s to liters/s
     d <- d %>%
@@ -298,14 +294,12 @@ process_1_9 <- function(network, domain, prodname_ms, site_name,
 
     d <- ms_cast_and_reflag(d,
                             varflag_col_pattern = NA,
-                            variable_flags_to_drop = NA,
-                            variable_flags_clean = NA,
-                            summary_flags_dirty = list('QUAL_FLAG' = 1,
-                                                       'MAINTENANCE_FLAG' = 1,
-                                                       'INCOMPLETE_FLAG' = 1),
-                            summary_flags_to_drop = list('QUAL_FLAG' = 6,
-                                                         'MAINTENANCE_FLAG' = 6,
-                                                         'INCOMPLETE_FLAG' = 6))
+                            summary_flags_to_drop = list('QUAL_FLAG' = '1',
+                                                         'MAINTENANCE_FLAG' = '1',
+                                                         'INCOMPLETE_FLAG' = '1'),
+                            summary_flags_clean = list('QUAL_FLAG' = c('0', '.'),
+                                                       'MAINTENANCE_FLAG' = c('0', '.'),
+                                                       'INCOMPLETE_FLAG' = c('0', '.')))
 
     # Convert from cm/s to liters/s
     d <- d %>%
@@ -359,14 +353,12 @@ process_1_10 <- function(network, domain, prodname_ms, site_name,
 
     d <- ms_cast_and_reflag(d,
                             varflag_col_pattern = NA,
-                            variable_flags_to_drop = NA,
-                            variable_flags_clean = NA,
-                            summary_flags_dirty = list('QUAL_FLAG' = 1,
-                                                       'MAINTENANCE_FLAG' = 1,
-                                                       'INCOMPLETE_FLAG' = 1),
-                            summary_flags_to_drop = list('QUAL_FLAG' = 6,
-                                                         'MAINTENANCE_FLAG' = 6,
-                                                         'INCOMPLETE_FLAG' = 6))
+                            summary_flags_to_drop = list('QUAL_FLAG' = '1',
+                                                         'MAINTENANCE_FLAG' = '1',
+                                                         'INCOMPLETE_FLAG' = '1'),
+                            summary_flags_clean = list('QUAL_FLAG' = c('0', '.'),
+                                                       'MAINTENANCE_FLAG' = c('0', '.'),
+                                                       'INCOMPLETE_FLAG' = c('0', '.')))
 
     # Convert from cm/s to liters/s
     d <- d %>%


### PR DESCRIPTION
- pflux now generated in correct units (kg/d)
- functions for getting road and stream layers from OpenStreetMap
- new options for interactive delineation (toggle burn streams, toggle breach type, set DEM resolution, set flat_increment)
- hjandrews kernel updates for watershed boundaries
- better auto-selection of projections
- fixed all questionable watershed boundaries
- raster/terra::boundary workaround (this is supposed to give the border of a DEM so we can evaluate whether the delineation hit an edge, but those functions can't produce a reliable border. used raster::focal to make workaround, and did this near the end of redelineating, so it might have some lurking issues that I didn't come across)
- other scattered bugfixes