### PR TITLE
neon update and general loop improvments

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -220,7 +220,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=24
+# dmnrow=18
 for(dmnrow in 1:nrow(network_domain)){
 
     # drop_automated_entries('.') #use with caution!

--- a/src/czo/boulder/derive.R
+++ b/src/czo/boulder/derive.R
@@ -6,7 +6,7 @@ prod_info <- get_product_info(network = network,
                              status_level = 'derive',
                              get_statuses = 'ready')
 
-# i=6
+# i=8
 for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])

--- a/src/global/general.R
+++ b/src/global/general.R
@@ -124,9 +124,48 @@ for(i in 1:nrow(unprod)){
     }
 }
 
-#this isn't needed, right?
-# create_portal_links(network = network,
-#                     domain = domain)
+# Link ws_traits to portal
+derive_dir <- glue('data/{n}/{d}/ws_traits',
+                   n = network,
+                   d = domain)
+
+portal_dir <- glue('../portal/data/{d}',
+                   d = domain)
+
+dir.create(portal_dir,
+           showWarnings = FALSE,
+           recursive = TRUE)
+
+dirs_to_build <- list.dirs(derive_dir,
+                           recursive = TRUE)
+dirs_to_build <- dirs_to_build[dirs_to_build != derive_dir]
+
+dirs_to_build <- convert_derive_path_to_portal_path(paths = dirs_to_build)
+
+for(dr in dirs_to_build){
+  dir.create(dr,
+             showWarnings = FALSE,
+             recursive = TRUE)
+}
+
+#"from" and "to" may seem counterintuitive here. keep in mind that files
+#as represented by the OS are actually all hardlinks to inodes in the kernel.
+#so when you make a new hardlink, you're linking *from* a new location
+#*to* an inode, as referenced by an existing hardlink. file.link uses
+#these words in a less realistic, but more intuitive way, i.e. *from*
+#an existing file *to* a new location
+files_to_link_from <- list.files(path = derive_dir,
+                                 recursive = TRUE,
+                                 full.names = TRUE)
+
+files_to_link_to <- convert_derive_path_to_portal_path(
+  paths = files_to_link_from)
+
+for(i in 1:length(files_to_link_from)){
+  unlink(files_to_link_to[i])
+  invisible(sw(file.link(to = files_to_link_to[i],
+                         from = files_to_link_from[i])))
+}
 
 loginfo(msg = 'General acquisition complete for all products',
         logger = logger_module)

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -5963,6 +5963,8 @@ write_precip_quickref <- function(precip_idw_list,
                                 tz = 'UTC'),
                        sep = '_')
 
+    chunkfile <- str_replace_all(chunkfile, ':', '-')
+
     saveRDS(object = precip_idw_list,
             file = glue('{qd}/{cf}', #omitting extension for easier parsing
                         qd = quickref_dir,
@@ -6063,10 +6065,10 @@ read_precip_quickref <- function(network,
     for(i in 1:nrow(refranges_sel)){
 
         fn <- paste(strftime(refranges_sel$startdt[i],
-                             format = '%Y-%m-%d %H:%M:%S',
+                             format = '%Y-%m-%d %H-%M-%S',
                              tz = 'UTC'),
                     strftime(refranges_sel$enddt[i],
-                             format = '%Y-%m-%d %H:%M:%S',
+                             format = '%Y-%m-%d %H-%M-%S',
                              tz = 'UTC'),
                     sep = '_')
 
@@ -7149,7 +7151,8 @@ precip_pchem_pflux_idw <- function(pchem_prodname,
                             foreach_chunk
                         }
 
-                    ms_unparallelize(clst)
+                        ms_unparallelize(clst)
+
 
                     rm(chemflux_chunklist); gc()
 
@@ -8754,10 +8757,12 @@ get_phonology <- function(network, domain, prodname_ms, time, site_boundary,
         final <- rbind(final, one_var)
         }
 
-    final <- pivot_longer(final,
-                          cols = all_of(c(mean_name, sd_name)),
-                          names_to = 'var',
-                          values_to = 'val') %>%
+    final <- final %>%
+        mutate(!!mean_name := round(.data[[mean_name]])) %>%
+        pivot_longer(final,
+                     cols = all_of(c(mean_name, sd_name)),
+                     names_to = 'var',
+                     values_to = 'val') %>%
         mutate(var = paste0('vd_', var)) %>%
         select(year, site_name, var, val, pctCellErr)
 
@@ -10026,8 +10031,8 @@ approxjoin_datetime <- function(x,
                         .cols = everything()) %>%
             as.data.table()
     } else {
-        x <- rename(x, datetime_x = datetime) %>% as.data.table()
-        y <- rename(y, datetime_y = datetime) %>% as.data.table()
+        x <- dplyr::rename(x, datetime_x = datetime) %>% as.data.table()
+        y <- dplyr::rename(y, datetime_y = datetime) %>% as.data.table()
     }
 
     #alternative implementation of the "on" argument in data.table joins...

--- a/src/krycklan/krycklan/derive.R
+++ b/src/krycklan/krycklan/derive.R
@@ -6,7 +6,7 @@ prod_info <- get_product_info(network = network,
                              status_level = 'derive',
                              get_statuses = 'ready')
 
-# i=4
+# i=8
 for(i in 1:nrow(prod_info)){
 
     prodname_ms <<- glue(prod_info$prodname[i], '__', prod_info$prodcode[i])

--- a/src/krycklan/krycklan/products.csv
+++ b/src/krycklan/krycklan/products.csv
@@ -4,11 +4,13 @@ VERSIONLESS002,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms002,NA,NA
 VERSIONLESS003,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,NA
 VERSIONLESS004,stream_temperature,ready,pending,NA,stream_chemistry__ms001,NA,NA
 VERSIONLESS005,ws_boundary,ready,ready,NA,NA,NA,NA
-VERSIONLESS006,precipitation,ready,ready,,precip_pchem_pflux__ms002,,
+VERSIONLESS006,precipitation,ready,ready,NA,precip_pchem_pflux__ms002,NA,NA
 ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms001,NA,NA
 ms002,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms003,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms002,NA,NA
-ms004,precip_pchem_pflux,NA,NA,ready,,NA,NA
+ms004,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
 ms005,discharge,NA,NA,linked,NA,automated entry,NA
 ms006,ws_boundary,NA,NA,linked,NA,automated entry,NA
 ms901,precip_chemistry,NA,NA,NA,NA,automated entry,NA
+ms900,precipitation,NA,NA,NA,NA,automated entry,NA
+ms902,precip_flux_inst,NA,NA,NA,NA,automated entry,NA

--- a/src/neon/neon/processing_kernels.R
+++ b/src/neon/neon/processing_kernels.R
@@ -27,7 +27,7 @@ process_0_DP1.20093 <- function(set_details, network, domain){
     return()
 }
 
-#stream_nitrate: STATUS=READY
+#stream_nitrate: STATUS=PAUSED
 #. handle_errors
 process_0_DP1.20033 <- function(set_details, network, domain){
 
@@ -52,7 +52,7 @@ process_0_DP1.20033 <- function(set_details, network, domain){
     return()
 }
 
-#stream_PAR: STATUS=READY
+#stream_PAR: STATUS=PAUSED
 #. handle_errors
 process_0_DP1.20042 <- function(set_details, network, domain){
 
@@ -77,7 +77,7 @@ process_0_DP1.20042 <- function(set_details, network, domain){
     return()
 }
 
-#stream_temperature: STATUS=READY
+#stream_temperature: STATUS=PAUSED
 #. handle_errors
 process_0_DP1.20053 <- function(set_details, network, domain){
 
@@ -131,7 +131,7 @@ process_0_DP1.00004 <- function(set_details, network, domain){
     return()
 }
 
-#stream_gases: STATUS=READY
+#stream_gases: STATUS=PAUSED
 #. handle_errors
 process_0_DP1.20097 <- function(set_details, network, domain){
 
@@ -208,7 +208,7 @@ process_0_DP1.20016 <- function(set_details, network, domain){
     return()
 }
 
-#stream_quality: STATUS=READY
+#stream_quality: STATUS=PAUSED
 #. handle_errors
 process_0_DP1.20288 <- function(set_details, network, domain){
 
@@ -379,7 +379,8 @@ process_1_DP1.20093 <- function(network, domain, prodname_ms, site_name,
             filter(!is.na(val)) %>%
             rename(site_name = siteID,
                    datetime = collectDate) %>%
-            mutate(datetime = force_tz(datetime, tzone = 'UTC'))
+            mutate(datetime = force_tz(datetime, tzone = 'UTC')) %>%
+            filter(!is.na(val))
 
 
     }
@@ -400,10 +401,17 @@ process_1_DP1.20093 <- function(network, domain, prodname_ms, site_name,
                                    var == 'specificConductance' ~ 'spCond',
                                    var == 'UV Absorbance (280 nm)' ~ 'abs280',
                                    var == 'UV Absorbance (250 nm)' ~ 'abs250',
+                                   var == 'UV Absorbance (254 nm)' ~ 'abs254',
                                    TRUE ~ var)) %>%
             mutate(val = ifelse(var == 'ANC', val/1000, val)) %>%
             filter(var != 'TSS - Dry Mass') %>%
             mutate(datetime = force_tz(datetime, 'UTC'))
+
+        # TEMPORARILY REMOVING NEON NUTRIENT DATA #
+        out_lab <- out_lab %>%
+          filter(! var %in% c('NH4_N', 'NO2_N', 'NO3_NO2_N', 'TN',
+                              'TPN', 'TDN', 'PO4_P')) %>%
+          filter(!is.na(val))
 
   }
 
@@ -435,14 +443,15 @@ process_1_DP1.20093 <- function(network, domain, prodname_ms, site_name,
         summarize(
             val = mean(val, na.rm=TRUE),
             ms_status = max(ms_status, na.rm = TRUE)) %>%
-        mutate(val = ifelse(is.nan(val), NA, val))
+        mutate(val = ifelse(is.nan(val), NA, val)) %>%
+        filter(!is.na(val))
 
     }
 
     return(out_sub)
 }
 
-#stream_nitrate: STATUS=READY
+#stream_nitrate: STATUS=PAUSED
 #. handle_errors
 process_1_DP1.20033 <- function(network, domain, prodname_ms, site_name,
     component){
@@ -479,7 +488,7 @@ process_1_DP1.20033 <- function(network, domain, prodname_ms, site_name,
     return(out_sub)
 }
 
-#stream_PAR: STATUS=READY
+#stream_PAR: STATUS=PAUSED
 #. handle_errors
 process_1_DP1.20042 <- function(network, domain, prodname_ms, site_name,
     component){
@@ -520,7 +529,7 @@ process_1_DP1.20042 <- function(network, domain, prodname_ms, site_name,
     return(out_sub)
 }
 
-#stream_temperature: STATUS=READY
+#stream_temperature: STATUS=PAUSED
 #. handle_errors
 process_1_DP1.20053 <- function(network, domain, prodname_ms, site_name,
     component){
@@ -637,7 +646,7 @@ process_1_DP1.00004 <- function(network, domain, prodname_ms, site_name,
     return(out_sub)
 }
 
-#stream_gases: STATUS=READY
+#stream_gases: STATUS=PAUSED
 #. handle_errors
 process_1_DP1.20097 <- function(network, domain, prodname_ms, site_name,
     component){
@@ -723,7 +732,7 @@ process_1_DP1.20016 <- function(network, domain, prodname_ms, site_name,
 
 }
 
-#stream_quality: STATUS=READY
+#stream_quality: STATUS=PAUSED
 #. handle_errors
 process_1_DP1.20288 <- function(network, domain, prodname_ms, site_name,
     component){
@@ -1080,3 +1089,7 @@ process_2_ms003 <- function(network, domain, prodname_ms) {
         }
     }
 }
+
+#stream_flux_inst: STATUS=READY
+#. handle_errors
+process_2_ms004 <- derive_stream_flux

--- a/src/neon/neon/products.csv
+++ b/src/neon/neon/products.csv
@@ -1,25 +1,26 @@
 prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 DP1.20093,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA
-DP1.20288,stream_quality,ready,ready,NA,stream_chemistry__ms001,NA
+DP1.20288,stream_quality,paused,paused,NA,stream_chemistry__ms001,NA
 DP?.20267,gageht,paused,pending,NA,NA,verify DP#
 DP?.00133,zqcurve,paused,pending,NA,NA,verify DP#
-DP4.00130,discharge,ready,ready,NA,NA,NA
+DP4.00130,discharge,ready,ready,NA,stream_flux_inst__ms004,NA
 DP?.20048,Qflowmeter,paused,pending,NA,NA,verify DP#
 DP?.20193,Qsalt,paused,pending,NA,NA,verify DP#
 DP?.20008,speccond,unavailiable,unavailiable,NA,NA,verify DP#
 DP1.20016,surfaceElev,paused,pending,NA,NA,NA
 DP?.20008,spec_cond,unavailiable,unavailiable,NA,NA,verify DP#
-DP1.20033,stream_nitrate,ready,ready,NA,stream_chemistry__ms001,NA
+DP1.20033,stream_nitrate,paused,paused,NA,stream_chemistry__ms001,NA
 DP1.00004,air_pressure,paused,paused,NA,NA,NA
-DP1.20097,stream_gases,ready,ready,NA,stream_chemistry__ms001,NA
+DP1.20097,stream_gases,paused,paused,NA,stream_chemistry__ms001,NA
 DP1.20016,surface_elevation,paused,paused,NA,NA,NA
-DP1.20053,stream_temperature,ready,ready,NA,stream_chemistry__ms001,NA
-DP1.20042,stream_PAR,ready,ready,NA,NA,NA
+DP1.20053,stream_temperature,paused,paused,NA,stream_chemistry__ms001,NA
+DP1.20042,stream_PAR,paused,paused,NA,NA,NA
 DP1.00006,precipitation,ready,ready,NA,precip_pchem_pflux__ms002,NA
 DP1.00013,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms002,NA
 VERSIONLESS001,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms002,NA
-ms001,stream_chemistry,NA,NA,ready,NA,NA
+ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms004,NA
 ms002,precipitation,NA,NA,ready,precip_flux_inst__ms003,NA
 ms003,precip_flux_inst,NA,NA,ready,NA,NA
-ms004,ws_boundary,NA,NA,linked,NA,automated entry
+ms004,stream_flux_inst,NA,NA,ready,NA,NA
 ms005,discharge,NA,NA,linked,NA,automated entry
+ms006,ws_boundary,NA,NA,linked,NA,automated entry

--- a/src/usfs/suef/products.csv
+++ b/src/usfs/suef/products.csv
@@ -10,3 +10,4 @@ ms003,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
 ms004,discharge,NA,NA,linked,NA,automated entry,NA
 ms005,stream_chemistry,NA,NA,linked,NA,automated entry,NA
 ms000,ws_boundary,NA,NA,NA,precip_pchem_pflux__ms003,automated entry,NA
+ms901,precip_chemistry,NA,NA,NA,NA,automated entry,NA


### PR DESCRIPTION
Three things here:

- NEON updated to remove nutrients and sensor variables.
- general loop improved to not saves files with all NAs or all 0 (which are really NAs for sites outside the extent of a dataset) and added ET grass reference.
- Precip interp function changed to make windows compatible. quick ref files are saved with all "-" instead of ":"s in the time format. 
@vlahm 