### PR TITLE
bugfixes, plum change, and some notes

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -192,7 +192,7 @@ ms_init <- function(use_gpu = FALSE,
     return(instance_details)
 }
 
-ms_instance <- ms_init(use_ms_error_handling = F,
+ms_instance <- ms_init(use_ms_error_handling = TRUE,
                     #   force_machine_status = 'n00b',
                        config_storage_location = 'remote')
 
@@ -239,9 +239,9 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow=21
+# dmnrow=26
 # print(network_domain, n=50)
-for(dmnrow in 3:nrow(network_domain)){
+for(dmnrow in 1:nrow(network_domain)){
 
     # drop_automated_entries('.') #use with caution!
     # drop_automated_entries(glue('data/{n}/{d}', n = network, d = domain))
@@ -274,20 +274,19 @@ for(dmnrow in 3:nrow(network_domain)){
     get_all_local_helpers(network = network,
                           domain = domain)
 
-    # ms_retrieve(network = network,
-    #             # prodname_filter = c('ws_boundary'),
-    #             domain = domain)
-    # ms_munge(network = network,
-    #          # prodname_filter = c('ws_boundary'),
-    #          domain = domain)
-    # sw(ms_delineate(network = network,
-    #                 domain = domain,
-    #                 dev_machine_status = ms_instance$machine_status,
-    #                 sites_from_gdrive = list(plum = c('cart_creek')),
-    #                 verbose = TRUE))
-    # ms_derive(network = network,
-    #           # prodname_filter = c('ws_boundary'),
-    #           domain = domain)
+    ms_retrieve(network = network,
+                # prodname_filter = c('ws_boundary'),
+                domain = domain)
+    ms_munge(network = network,
+             # prodname_filter = c('ws_boundary'),
+             domain = domain)
+    sw(ms_delineate(network = network,
+                    domain = domain,
+                    dev_machine_status = ms_instance$machine_status,
+                    verbose = TRUE))
+    ms_derive(network = network,
+              # prodname_filter = c('ws_boundary'),
+              domain = domain)
     ms_general(network = network,
                domain = domain)
 

--- a/src/doe/east_river/products.csv
+++ b/src/doe/east_river/products.csv
@@ -1,17 +1,18 @@
 prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,components,url
-VERSIONLESS001,precipitation,ready,ready,NA,precip_pchem_pflux__ms005,NA,east_river_met,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-04a0bf909a5e63a-20201207T194832971
+VERSIONLESS001,precipitation,ready,ready,NA,precip_pchem_pflux__ms006,NA,east_river_met,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-04a0bf909a5e63a-20201207T194832971
 VERSIONLESS002,discharge,ready,ready,NA,discharge__ms002,NA,east_river_discharge,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/packages/application%2Fbagit-097/ess-dive-39d95e263bec24d-20190301T155200040382
 VERSIONLESS003,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,east_river_isotopes,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-1a238fda8efff28-20201008T062924406
 VERSIONLESS004,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,east_river_cations,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-00d153692f1826b-20201008T064447692
 VERSIONLESS005,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,east_river_anions,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-b2f6dc82c561acf-20201008T063210052
 VERSIONLESS006,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,east_river_carbon,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-7129d0cae9524f7-20201008T064208417
 VERSIONLESS007,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,east_river_nitrogen,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/object/ess-dive-27b02333d31ae19-20201008T063638376
-VERSIONLESS008,ws_boundary,ready,ready,NA,NA,NA,east_river_ws_boundaries,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/packages/application%2Fbagit-097/ess-dive-3b9a58adc163fd4-20190509T155206477018
+VERSIONLESS008,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms006,NA,east_river_ws_boundaries,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/packages/application%2Fbagit-097/ess-dive-3b9a58adc163fd4-20190509T155206477018
 VERSIONLESS009,discharge,ready,ready,NA,discharge__ms002,NA,east_river_discharge_v2,https://data.ess-dive.lbl.gov/catalog/d1/mn/v2/packages/application%2Fbagit-097/ess-dive-ed7388a0308c456-20210430T041037813424
-ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms002,NA,NA,NA
-ms002,discharge,NA,NA,ready,stream_flux_inst__ms002,NA,NA,NA
+ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms003,NA,NA,NA
+ms002,discharge,NA,NA,ready,stream_flux_inst__ms003,NA,NA,NA
 ms003,stream_flux_inst,NA,NA,ready,NA,NA,NA,NA
-ms004,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms005,NA,NA,NA
+ms004,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms006,NA,NA,NA
 ms005,stream_gauge_locations,NA,NA,ready,NA,NA,NA,NA
 ms006,precip_pchem_pflux,NA,NA,ready,NA,NA,NA,NA
 ms007,ws_boundary,NA,NA,linked,NA,automated entry,NA,NA
+ms900,precipitation,NA,NA,NA,NA,automated entry,NA,NA

--- a/src/global/general.R
+++ b/src/global/general.R
@@ -14,9 +14,9 @@ unprod <- univ_products %>%
 
 # Load spatial files from Drive if not already held on local machine
 # (takes a long time)
-# load_spatial_data()
+load_spatial_data()
 
-# Load in watershed Boundaries 
+# Load in watershed Boundaries
 files <- list.files(glue('data/{n}/{d}/derived/',
                          n = network,
                          d = domain))
@@ -42,7 +42,7 @@ gee_file_exist <- try(rgee::ee_manage_assetlist(asset_folder), silent = TRUE)
 if(class(gee_file_exist) == 'try-error' || nrow(gee_file_exist) == 0){
   loginfo('Uploading ws_boundaries to GEE',
           logger = logger_module)
-  
+
   sm(rgee::ee_manage_create(asset_folder))
 
   asset_path <- paste0(asset_folder, '/', 'all_ws_boundaries')
@@ -53,7 +53,7 @@ if(class(gee_file_exist) == 'try-error' || nrow(gee_file_exist) == 0){
                            overwrite = TRUE,
                            quiet = TRUE),
                   silent = TRUE)
-  
+
   if('try-error' %in% class(ee_shape)){
 
     for(i in 1:nrow(boundaries)){
@@ -88,7 +88,7 @@ for(i in 1:nrow(unprod)){
     loginfo(glue('Acquiring product: {p}',
                  p = prodname_ms),
             logger = logger_module)
-  
+
     site_code <- 'all_sites'
 
     if(! site_is_tracked(held_data, prodname_ms, site_code)){
@@ -101,7 +101,7 @@ for(i in 1:nrow(unprod)){
     general_status <- get_general_status(tracker = held_data,
                                          prodname_ms = prodname_ms,
                                          site_code = site_code)
-    
+
 
     if(general_status %in% c('ok', 'no_data_avail')){
 

--- a/src/global/general.R
+++ b/src/global/general.R
@@ -10,7 +10,7 @@ if(ms_instance$use_ms_error_handling){
 
 unprod <- univ_products %>%
     filter(status == 'ready') %>%
-    filter(! grepl('prism', prodname))
+    filter(grepl('prism', prodname))
 
 # Load spatial files from Drive if not already held on local machine
 # (takes a long time)
@@ -24,8 +24,8 @@ files <- list.files(glue('data/{n}/{d}/derived/',
 ws_prodname <- grep('ws_boundary', files, value = TRUE)
 
 boundaries <- try(read_combine_shapefiles(network = network,
-                                     domain = domain,
-                                     prodname_ms = ws_prodname))
+                                          domain = domain,
+                                          prodname_ms = ws_prodname))
 
 if(class(boundaries)[1] == 'ms_err' | is.null(boundaries[1])){
     stop('Watershed boundaries are required for general products')
@@ -40,6 +40,7 @@ asset_folder <- glue('{a}/macrosheds_ws_boundaries/{d}/',
 gee_file_exist <- try(rgee::ee_manage_assetlist(asset_folder), silent = TRUE)
 
 if(class(gee_file_exist) == 'try-error' || nrow(gee_file_exist) == 0){
+
   loginfo('Uploading ws_boundaries to GEE',
           logger = logger_module)
 

--- a/src/global/general.R
+++ b/src/global/general.R
@@ -9,7 +9,8 @@ if(ms_instance$use_ms_error_handling){
 }
 
 unprod <- univ_products %>%
-    filter(status == 'ready')
+    filter(status == 'ready') %>%
+    filter(! grepl('prism', prodname))
 
 # Load spatial files from Drive if not already held on local machine
 # (takes a long time)

--- a/src/global/general_kernels.R
+++ b/src/global/general_kernels.R
@@ -35,12 +35,12 @@ process_3_ms805 <- function(network, domain, prodname_ms, site_code,
     }
 
     npp <- append_unprod_prefix(npp, prodname_ms)
-    
+
     dir <- glue('data/{n}/{d}/ws_traits/npp/',
                 n = network,
                 d = domain)
-    
-    save_general_files(final_file = npp, 
+
+    save_general_files(final_file = npp,
                        domain_dir = dir)
 
     return()
@@ -110,16 +110,16 @@ process_3_ms806 <- function(network, domain, prodname_ms, site_code,
 
     gpp_raw <- gpp %>%
         select(datetime, site_code, var, val)
-    
+
     gpp_final <- append_unprod_prefix(gpp_final, prodname_ms)
     gpp_raw <- append_unprod_prefix(gpp_raw, prodname_ms)
 
     dir <- glue('data/{n}/{d}/ws_traits/gpp/',
                  n = network,
                  d = domain)
-    
-    save_general_files(final_file = gpp_final, 
-                       raw_file = gpp_raw, 
+
+    save_general_files(final_file = gpp_final,
+                       raw_file = gpp_raw,
                        domain_dir = dir)
 
     return()
@@ -189,8 +189,8 @@ process_3_ms807 <- function(network, domain, prodname_ms, site_code,
     dir <- glue('data/{n}/{d}/ws_traits/lai/',
                 n = network, d = domain)
 
-    save_general_files(final_file = lai_final, 
-                       raw_file = lai_raw, 
+    save_general_files(final_file = lai_final,
+                       raw_file = lai_raw,
                        domain_dir = dir)
 
   }
@@ -249,16 +249,16 @@ process_3_ms807 <- function(network, domain, prodname_ms, site_code,
 
     fpar_raw <- fpar %>%
       select(datetime, site_code, val, var)
-    
+
     fpar_final <- append_unprod_prefix(fpar_final, prodname_ms)
-    
+
     fpar_raw <- append_unprod_prefix(fpar_raw, prodname_ms)
 
     dir <- glue('data/{n}/{d}/ws_traits/fpar/',
                 n = network, d = domain)
-    
-    save_general_files(final_file = fpar_final, 
-                       raw_file = fpar_raw, 
+
+    save_general_files(final_file = fpar_final,
+                       raw_file = fpar_raw,
                        domain_dir = dir)
 
     return()
@@ -319,12 +319,12 @@ process_3_ms808 <- function(network, domain, prodname_ms, site_code,
 
     var_final <- var %>%
         select(site_code, year, var, val)
-    
+
     var_final <- append_unprod_prefix(var_final, prodname_ms)
 
     dir <- glue('data/{n}/{d}/ws_traits/{v}/',
                 n = network, d = domain, v = type)
-    
+
     save_general_files(final_file = var_final,
                        domain_dir = dir)
 
@@ -434,10 +434,10 @@ process_3_ms809 <- function(network, domain, prodname_ms, site_code,
 
   dir <- glue('data/{n}/{d}/ws_traits/{v}/',
               n = network, d = domain, v = type)
-  
+
   final <- append_unprod_prefix(final, prodname_ms)
   final_sum <- append_unprod_prefix(final_sum, prodname_ms)
-  
+
   save_general_files(final_file = final_sum,
                      raw_file = final,
                      domain_dir = dir)
@@ -452,39 +452,39 @@ process_3_ms810 <- function(network, domain, prodname_ms, site_code,
 
   sites <- boundaries$site_code
   for(s in 1:length(sites)){
-    
+
     site_boundary <- boundaries %>%
       filter(site_code == sites[s])
-    
+
     site <- sites[s]
-    
+
     if(prodname_ms == 'start_season__ms810') {
-      
+
       sm(get_phonology(network=network, domain=domain, prodname_ms=prodname_ms,
-                       time='start_season', site_boundary=site_boundary, 
+                       time='start_season', site_boundary=site_boundary,
                        site_code=site))
-      
+
     }
-    
+
     if(prodname_ms == 'max_season__ms810') {
-      
+
       sm(get_phonology(network=network, domain=domain, prodname_ms=prodname_ms,
-                       time='max_season', site_boundary=site_boundary, 
+                       time='max_season', site_boundary=site_boundary,
                        site_code=site))
-      
+
     }
-    
+
     if(prodname_ms == 'end_season__ms810') {
-      
+
       sm(get_phonology(network=network, domain=domain, prodname_ms=prodname_ms,
                        time='end_season', site_boundary=site_boundary,
                        site_code=site))
     }
-    
+
     if(prodname_ms == 'season_length__ms810') {
-      
+
       sm(get_phonology(network=network, domain=domain, prodname_ms=prodname_ms,
-                       time='length_season', site_boundary=site_boundary, 
+                       time='length_season', site_boundary=site_boundary,
                        site_code=site))
     }
   }
@@ -501,24 +501,24 @@ process_3_ms811 <- function(network, domain, prodname_ms, site_code,
                n = network,
                d = domain), recursive = TRUE)
 
-  
+
   sites <- boundaries$site_code
   for(s in 1:length(sites)){
     site_boundary <- boundaries %>%
       filter(site_code == !!sites[s])
-    
+
     area <- as.numeric(sf::st_area(site_boundary)/1000000)
-    
+
     z_level <- case_when(area > 50 ~ 8,
                          area >= 25 & area <= 50 ~ 12,
                          area < 25 ~ 14)
-    
+
     dem <- elevatr::get_elev_raster(site_boundary, z = z_level)
-    
+
     dem <- dem %>%
       terra::crop(., site_boundary) %>%
       terra::mask(., site_boundary)
-    
+
     # Elevation
     elev_values <- raster::values(dem)
     elev_values <- elev_values[elev_values >= 0]
@@ -526,34 +526,34 @@ process_3_ms811 <- function(network, domain, prodname_ms, site_code,
     elev_sd <- sd(elev_values, na.rm = TRUE)
     elev_min <- min(elev_values, na.rm = TRUE)
     elev_max <- max(elev_values, na.rm = TRUE)
-    
+
     # Slope
     dem_path <- tempfile(fileext = '.tif')
     raster::writeRaster(dem, dem_path)
     slope_path <- tempfile(fileext = '.tif')
-    
+
     whitebox::wbt_slope(dem_path, slope_path)
-    
+
     slope <- raster::raster(slope_path) %>%
       terra::crop(., site_boundary) %>%
       terra::mask(., site_boundary)
-    
+
     slope_values <- raster::values(slope)
     slope_mean <- mean(slope_values, na.rm = TRUE)
     slope_sd <- sd(slope_values, na.rm = TRUE)
-    
+
     # Aspect
     aspect_path <- tempfile(fileext = '.tif')
     whitebox::wbt_aspect(dem_path, aspect_path)
-    
+
     aspect <- raster::raster(aspect_path) %>%
       terra::crop(., site_boundary) %>%
       terra::mask(., site_boundary)
-    
+
     aspect_values <- raster::values(aspect)
     aspect_mean <- mean(aspect_values, na.rm = TRUE)
     aspect_sd <- sd(aspect_values, na.rm = TRUE)
-    
+
     site_terrain <- tibble(year = NA,
                            site_code = sites[s],
                            var = c('slope_mean', 'slope_sd', 'elev_mean',
@@ -561,14 +561,14 @@ process_3_ms811 <- function(network, domain, prodname_ms, site_code,
                                    'aspect_mean', 'aspect_sd'),
                            val = c(slope_mean, slope_sd, elev_mean, elev_sd, elev_min,
                                    elev_max, aspect_mean, aspect_sd))
-    
+
     site_terrain <- append_unprod_prefix(site_terrain, prodname_ms)
-    
+
     write_feather(site_terrain, glue('data/{n}/{d}/ws_traits/terrain/{s}.feather',
                                      n = network,
                                      d = domain,
                                      s = sites[s]))
-    
+
   }
 }
 
@@ -581,10 +581,10 @@ process_3_ms812 <- function(network, domain, prodname_ms, site_code,
                     n = network,
                     d = domain), recursive = TRUE)
 
-  
+
   sites <- boundaries$site_code
   for(s in 1:length(sites)){
-    
+
     # Soil Organic Matter
     soil_tib <- sm(get_nrcs_soils(network = network,
                                   domain = domain,
@@ -698,7 +698,7 @@ process_3_ms812 <- function(network, domain, prodname_ms, site_code,
                                   # 'soil_plasticity_index' = 'pi_r'
                                   site = sites[s],
                                   ws_boundaries = boundaries))
-    
+
     if(is_ms_exception(soil_tib)) {
       return(soil_tib)
     } else{
@@ -719,30 +719,30 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
   nlcd_dir <- glue('data/{n}/{d}/ws_traits/nlcd/',
                    n = network,
                    d = domain)
-  
+
   dir.create(nlcd_dir,
              recursive = TRUE,
              showWarnings = FALSE)
-  
-  
+
+
   # Load landcover defs
   color_key = read_csv('data/spatial/nlcd/pixel_color_key.csv')
-  
+
   nlcd_summary = color_key %>%
     as_tibble() %>%
     select(1, 3) %>%
     rename(id = class_code) %>%
     mutate(id = as.character(id))
-  
+
   # 1992 to common name here: https://pubs.usgs.gov/of/2008/1379/pdf/ofr2008-1379.pdf
   color_key_1992 = read_csv('data/spatial/nlcd/1992_pixel_color_key.csv')
-  
+
   nlcd_summary_1992 = color_key_1992 %>%
     as_tibble() %>%
     select(class_code, macrosheds_1992_code, macrosheds_code) %>%
     rename(id = class_code) %>%
     mutate(id = as.character(id))
-  
+
   all_ee_task <- c()
   needed_files <- c()
   nlcd_all <- tibble()
@@ -751,48 +751,48 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
     # Get site boundary and check if the watershed is in Puerto Rico, Alaska, or Hawaii
     site_boundary <- boundaries %>%
       filter(site_code == sites[s])
-    
+
     ak_bb <- sf::st_bbox(obj	= c(xmin = -173, ymin = 51.22, xmax = -129,
                                  ymax = 71.35), crs = 4326) %>%
       sf::st_as_sfc(., crs = 4326)
-    
+
     pr_bb <- sf::st_bbox(obj	= c(xmin = -67.95, ymin = 17.91, xmax = -65.22,
                                  ymax = 18.51), crs = 4326) %>%
       sf::st_as_sfc(., crs = 4326)
-    
+
     hi_bb <- sf::st_bbox(obj	= c(xmin = -160.24, ymin = 18.91, xmax = -154.81,
                                  ymax = 22.23), crs = 4326) %>%
       sf::st_as_sfc(., crs = 4326)
-    
+
     usa_bb <- sf::st_bbox(obj	= c(xmin = -124.725, ymin = 24.498, xmax = -66.9499,
                                   ymax = 49.384), crs = 4326) %>%
       sf::st_as_sfc(., crs = 4326)
-    
+
     is_ak <- length(sm(sf::st_intersects(ak_bb, site_boundary))[[1]]) == 1
     is_pr <- length(sm(sf::st_intersects(pr_bb, site_boundary))[[1]]) == 1
     is_hi <- length(sm(sf::st_intersects(hi_bb, site_boundary))[[1]]) == 1
     is_usa <- length(sm(sf::st_intersects(usa_bb, site_boundary))[[1]]) == 1
-    
+
     if(is_ak){ nlcd_epochs = c('2001_AK', '2011_AK', '2016_AK') }
     if(is_pr){ nlcd_epochs = '2001_PR' }
     if(is_hi){ nlcd_epochs = '2001_HI' }
     if(is_usa){
       nlcd_epochs = as.character(c(1992, 2001, 2004, 2006, 2008, 2011, 2013, 2016))
     }
-    
+
     if(!is_ak && !is_pr && !is_hi && !is_usa){
-      
+
       return(generate_ms_exception(glue('No data was retrived for {s}',
                                         s = site_code)))
     }
-    
+
     user_info <- rgee::ee_user_info(quiet = TRUE)
     asset_folder <- glue('{a}/macrosheds_ws_boundaries/{d}/',
                          a = user_info$asset_home,
                          d = domain)
-    
+
     asset_path <- rgee::ee_manage_assetlist(asset_folder)
-    
+
     if(nrow(asset_path) == 1){
       ws_boundary_asset <- ee$FeatureCollection(asset_path$ID)
       filter_ee <- ee$Filter$inList('site_code', c(sites[s], sites[s]))
@@ -800,7 +800,7 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
     } else {
       ws_boundary_asset <- str_split_fixed(asset_path$ID, '/', n = Inf)
       ws_boundary_asset <- ws_boundary_asset[,ncol(ws_boundary_asset)]
-      
+
       this_asset <- asset_path[grep(sites[s], ws_boundary_asset),]
       site_ws_asset <- ee$FeatureCollection(this_asset$ID)
     }
@@ -813,14 +813,14 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
         filter(ee$Filter$eq('system:index', e))$
         first()$
         clip(site_ws_asset)
-      
+
       ee_description <-  glue('{n}_{d}_{s}_{p}_{e}',
                               d = domain,
                               n = network,
                               s = sites[s],
                               p = str_split_fixed(prodname_ms, '__', n = Inf)[1,1],
                               e = e)
-      
+
       file_name <- paste0('nlcdX_X', e, 'X_X', sites[s])
       ee_task <- ee$batch$Export$image$toDrive(image = img,
                                                description = ee_description,
@@ -829,13 +829,13 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
                                                region = site_ws_asset$geometry(),
                                                fileNamePrefix = file_name,
                                                maxPixels=NULL)
-      
+
       needed_files <- c(needed_files, file_name)
       all_ee_task <- c(all_ee_task, ee_description)
-      
+
       try(googledrive::drive_rm(paste0('GEE/', file_name, '.tif')),
           silent = TRUE) #in case previous drive_rm failed
-      
+
       start_mess <- try(ee_task$start())
       if(class(start_mess) == 'try-error'){
         return(generate_ms_err(glue('error in retrieving {s}',
@@ -844,36 +844,36 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
       #ee_monitoring(ee_task)
     }
   }
-    
+
     needed_files <- paste0(needed_files, '.tif')
-    
+
     talsk_running <- rgee::ee_manage_task()
-    
+
     talsk_running <- talsk_running %>%
       filter(DestinationPath %in% all_ee_task)
 
     while(any(talsk_running$State %in% c('RUNNING', 'READY'))) {
       talsk_running <- rgee::ee_manage_task()
-      
+
       talsk_running <- talsk_running %>%
         filter(DestinationPath %in% all_ee_task)
-      
+
       Sys.sleep(5)
     }
       temp_rgee <- tempfile(fileext = '.tif')
-      
+
       for(i in 1:length(needed_files)){
-        
+
         rel_file <- needed_files[i]
-        
+
         string <- str_split_fixed(rel_file, '[.]', n = Inf)[1,1]
         string <- str_split_fixed(string, 'X_X', n = Inf)
-        
+
         year <- string[1,2]
         site <- string[1,3]
-        
+
         file_there <- googledrive::drive_get(paste0('GEE/', rel_file))
-        
+
         if(nrow(file_there) == 0){ next }
         expo_backoff(
           expr = {
@@ -883,7 +883,7 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
           },
           max_attempts = 5
         ) %>% invisible()
-        
+
         nlcd_rast <- terra::rast(temp_rgee)
 
         nlcd_rast[as.vector(terra::values(nlcd_rast)) == 0] <- NA
@@ -899,20 +899,20 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
         if(length(str_split_fixed(year, '_', n = Inf)[1,]) == 2){
           year <- as.numeric(str_split_fixed(year, pattern = '_', n = Inf)[1,1])
         }
-        
+
         if(year == 1992){
-          
+
           nlcd_e = full_join(nlcd_summary_1992,
                              tabulated_values,
                              by = 'id') %>%
             mutate(sum = sum(CellTally, na.rm = TRUE))
-          
+
           nlcd_e_1992names <- nlcd_e %>%
             mutate(percent = round((CellTally/sum)*100, 1)) %>%
             mutate(percent = ifelse(is.na(percent), 0, percent)) %>%
             select(var = macrosheds_1992_code, val = percent) %>%
             mutate(year = !!year)
-          
+
           nlcd_e_norm_names <- nlcd_e %>%
             group_by(macrosheds_code) %>%
             summarise(CellTally1992 = sum(CellTally, na.rm = TRUE)) %>%
@@ -922,16 +922,16 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
             mutate(percent = ifelse(is.na(percent), 0, percent)) %>%
             select(var = macrosheds_code, val = percent) %>%
             mutate(year = !!year)
-          
+
           nlcd_e <- rbind(nlcd_e_1992names, nlcd_e_norm_names) %>%
             mutate(site_code = !!site)
-          
+
         } else{
-          
+
           nlcd_e = full_join(nlcd_summary,
                              tabulated_values,
                              by = 'id')
-          
+
           nlcd_e <- nlcd_e %>%
             mutate(percent = round((CellTally*100)/sum(CellTally, na.rm = TRUE), 1)) %>%
             mutate(percent = ifelse(is.na(percent), 0, percent)) %>%
@@ -941,14 +941,14 @@ process_3_ms813 <- function(network, domain, prodname_ms, site_code,
         }
         nlcd_all = rbind(nlcd_all, nlcd_e)
       }
-    
+
     nlcd_final <- nlcd_all %>%
       mutate(year = as.numeric(year)) %>%
       select(year, site_code, var, val)
-    
+
     nlcd_final <- append_unprod_prefix(nlcd_final, prodname_ms)
-    
-    save_general_files(final_file = nlcd_final, 
+
+    save_general_files(final_file = nlcd_final,
                        domain_dir = nlcd_dir)
 
 }
@@ -969,55 +969,55 @@ process_3_ms814 <- function(network, domain, prodname_ms, site_code,
   dir.create(nadp_dir, recursive = TRUE, showWarnings = FALSE)
 
   nadp_files <- list.files('data/spatial/ndap', recursive = TRUE, full.names = TRUE)
-  
+
   sites <- boundaries$site_code
   for(s in 8:length(sites)){
-    
+
     site_boundary <- boundaries %>%
       filter(site_code == !!sites[s])
-    
+
     usa_bb <- sf::st_bbox(obj	= c(xmin = -124.725, ymin = 24.498, xmax = -66.9499,
                                   ymax = 49.384), crs = 4326) %>%
       sf::st_as_sfc(., crs = 4326)
-    
+
     is_usa <- length(sm(sf::st_intersects(usa_bb, site_boundary))[[1]]) == 1
-    
+
     if(!is_usa){
       msg <- generate_ms_exception(glue('No data available for {s}',
                                         s = sites[s]))
-      
+
       loginfo(msg = msg,
-              logger = logger_module)    
+              logger = logger_module)
       next
       }
-    
+
     all_vars <- tibble()
     for(p in 1:length(nadp_files)){
-      
+
       year <- str_split_fixed(nadp_files[p], '/', n = Inf)[1,4]
       var <- str_split_fixed(str_split_fixed(nadp_files[p], '/', n = Inf)[1,5], '_', Inf)[1,2]
-      
+
       ws_values <- try(extract_ws_mean(site_boundary = site_boundary,
                                        raster_path = nadp_files[p]),
                        silent = TRUE)
-      
+
       if(class(ws_values) == 'try-error') { next }
-    
-      
+
+
       val_mean <- round(unname(ws_values['mean']), 3)
       val_sd <- round(unname(ws_values['sd']), 3)
       percent_na <-round(unname(ws_values['pctCellErr']), 2)
-      
+
       one_year_var <- tibble(year = year,
                              val = c(val_mean, val_sd),
                              var = c(var, var),
                              pctCellErr = percent_na,
                              type = c('mean', 'sd_space'),
                              site_code = !!sites[s])
-      
+
       all_vars <- rbind(all_vars, one_year_var)
     }
-    
+
     fin_nadp <- all_vars %>%
       mutate(var = case_when(var == 'ca' ~ 'annual_Ca_flux',
                              var == 'cl' ~ 'annual_Cl_flux',
@@ -1033,11 +1033,11 @@ process_3_ms814 <- function(network, domain, prodname_ms, site_code,
       mutate(var = paste0(var, '_', type)) %>%
       mutate(year = as.numeric(year)) %>%
       select(year, site_code, var, val)
-    
+
     if(all(is.na(fin_nadp$val))){
       msg <- generate_ms_exception(glue('No data was retrived for {s}',
                                         s = site_code))
-      
+
       loginfo(msg = msg,
               logger = logger_module)
     } else{
@@ -1046,7 +1046,7 @@ process_3_ms814 <- function(network, domain, prodname_ms, site_code,
                                    d = nadp_dir,
                                    s = sites[s]))
     }
-    
+
   }
 }
 
@@ -1065,23 +1065,23 @@ process_3_ms815 <- function(network, domain, prodname_ms, site_code,
 
   sites <- boundaries$site_code
   for(s in 1:length(sites)){
-  
+
     site_boundary <- boundaries %>%
       filter(site_code == !!sites[s])
-    
+
     thinkness_files <- 'data/spatial/pelletier_soil_thickness/average_soil_and_sedimentary-deposit_thickness.tif'
-    
-    
+
+
     ws_values <- try(extract_ws_mean(site_boundary = site_boundary,
                                      raster_path = thinkness_files))
-    
-    
+
+
     if(class(ws_values) == 'try-error'){
-      
+
       return(generate_ms_exception(glue('No data was retrived for {s}',
                                         s = site_code)))
     }
-    
+
     thinkness_tib <- tibble(year = NA,
                             val = unname(ws_values['mean']),
                             var = 'soil_thickness',
@@ -1089,12 +1089,12 @@ process_3_ms815 <- function(network, domain, prodname_ms, site_code,
                             ms_status = NA)  %>%
       mutate(site_code = !!sites[s]) %>%
       select(year, site_code, var, val, pctCellErr)
-    
+
     thinkness_tib <- append_unprod_prefix(thinkness_tib, prodname_ms)
     write_feather(thinkness_tib, glue('{d}{s}.feather',
                                       d = thickness_dir,
                                       s = sites[s]))
-    
+
   }
 }
 
@@ -1110,52 +1110,52 @@ process_3_ms816 <- function(network, domain, prodname_ms, site_code,
   dir.create(geomchem_dir, recursive = TRUE, showWarnings = FALSE)
 
   geomchem_files <- list.files('data/spatial/geochemical', recursive = TRUE, full.names = TRUE)
-  
-  
+
+
   sites <- boundaries$site_code
   for(s in 1:length(sites)){
 
     site_boundary <- boundaries %>%
       filter(site_code == !!sites[s])
-    
+
     all_vars <- tibble()
     for(p in 1:length(geomchem_files)){
-      
+
       var <- str_split_fixed(geomchem_files[p], '/', n = Inf)[1,4]
       var <- str_split_fixed(var, '[.]', n = Inf)[1,1]
       var <- str_split_fixed(var, '_', n = Inf)[1,1]
-      
+
       ws_values <- try(extract_ws_mean(site_boundary = site_boundary,
                                        raster_path = geomchem_files[p]),
                        silent = TRUE)
-      
+
       if(class(ws_values) == 'try-error') {
         return(generate_ms_exception(glue('No data was retrived for {s}',
                                           s = site_code)))
       }
-      
+
       val_mean <- round(unname(ws_values['mean']), 2)
       val_sd <- round(unname(ws_values['sd']), 2)
       percent_na <-round(unname(ws_values['pctCellErr']), 2)
-      
+
       one_var <- tibble(val = c(val_mean, val_sd),
                         var = c(paste0(var, '_mean'), paste0(var, '_sd')),
                         pctCellErr = percent_na)
-      
+
       all_vars <- rbind(all_vars, one_var)
     }
-    
+
     all_vars <- all_vars %>%
       mutate(site_code = !!sites[s],
              year = NA,
              var = paste0('geo_', var)) %>%
       select(year, site_code, var, val)
-    
+
     all_vars <- append_unprod_prefix(all_vars, prodname_ms)
     write_feather(all_vars, glue('{d}/{s}.feather',
                                  d = geomchem_dir,
                                  s = sites[s]))
-    
+
   }
 }
 
@@ -1212,14 +1212,14 @@ process_3_ms817 <- function(network, domain, prodname_ms, site_code,
 
     ndvi_raw <- ndvi %>%
         select(datetime, site_code, var, val)
-    
+
     ndvi_final <- append_unprod_prefix(ndvi_final, prodname_ms)
-    
+
     ndvi_raw <- append_unprod_prefix(ndvi_raw, prodname_ms)
 
     dir <- glue('data/{n}/{d}/ws_traits/ndvi/',
                 n = network, d = domain)
-    
+
     save_general_files(final_file = ndvi_final,
                        raw_file = ndvi_raw,
                        domain_dir = dir)
@@ -1232,50 +1232,50 @@ process_3_ms817 <- function(network, domain, prodname_ms, site_code,
 process_3_ms818 <- function(network, domain, prodname_ms, site_code,
                             boundaries) {
 
-  # https://gaftp.epa.gov/epadatacommons/ORD/NHDPlusLandscapeAttributes/StreamCat/Documentation/DataDictionary.html
-  # https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1304
+    # https://gaftp.epa.gov/epadatacommons/ORD/NHDPlusLandscapeAttributes/StreamCat/Documentation/DataDictionary.html
+    # https://daac.ornl.gov/cgi-bin/dsviewer.pl?ds_id=1304
 
-  bfi_dir <- glue('data/{n}/{d}/ws_traits/bfi/',
-                        n = network,
-                        d = domain)
+    bfi_dir <- glue('data/{n}/{d}/ws_traits/bfi/',
+                          n = network,
+                          d = domain)
 
-  dir.create(bfi_dir, recursive = TRUE, showWarnings = FALSE)
+    dir.create(bfi_dir,
+               recursive = TRUE,
+               showWarnings = FALSE)
 
-  bfi_files <- 'data/spatial/bfi.tif'
-  sites <- boundaries$site_code
-  for(s in 1:length(sites)){
-    
-    site_boundary <- boundaries %>%
-      filter(site_code == !!sites[s])
-    
-    
-    ws_values <- try(extract_ws_mean(site_boundary = site_boundary,
-                                     raster_path = bfi_files),
-                     silent = TRUE)
-    
-    if(class(ws_values) == 'try-error') {
-      return(generate_ms_exception(glue('No data was retrived for {s}',
-                                        s = site_code)))
+    bfi_files <- 'data/spatial/bfi.tif'
+    sites <- boundaries$site_code
+    for(s in 1:length(sites)){
+
+        site_boundary <- boundaries %>%
+            filter(site_code == !!sites[s])
+
+        ws_values <- try(extract_ws_mean(site_boundary = site_boundary,
+                                         raster_path = bfi_files),
+                         silent = TRUE)
+
+        if(inherits(ws_values, 'try-error')){
+            return(generate_ms_exception(glue('No data was retrived for {s}',
+                                              s = site_code)))
+        }
+
+        val_mean <- round(unname(ws_values['mean']), 2)
+        val_sd <- round(unname(ws_values['sd']), 2)
+        percent_na <-round(unname(ws_values['pctCellErr']), 2)
+
+        bfi_tib <- tibble(year = NA,
+                          val = c(val_mean, val_sd),
+                          var = c('bfi_mean', 'bfi_sd'),
+                          pctCellErr = percent_na,
+                          ms_status = NA)  %>%
+            mutate(site_code = !!sites[s]) %>%
+            select(year, site_code, var, val, pctCellErr)
+
+        bfi_tib <- append_unprod_prefix(bfi_tib, prodname_ms)
+        write_feather(bfi_tib, glue('{d}{s}.feather',
+                                    d = bfi_dir,
+                                    s = sites[s]))
     }
-    
-    val_mean <- round(unname(ws_values['mean']), 2)
-    val_sd <- round(unname(ws_values['sd']), 2)
-    percent_na <-round(unname(ws_values['pctCellErr']), 2)
-    
-    bfi_tib <- tibble(year = NA,
-                      val = c(val_mean, val_sd),
-                      var = c('bfi_mean', 'bfi_sd'),
-                      pctCellErr = percent_na,
-                      ms_status = NA)  %>%
-      mutate(site_code = !!sites[s]) %>%
-      select(year, site_code, var, val, pctCellErr)
-    
-    bfi_tib <- append_unprod_prefix(bfi_tib, prodname_ms)
-    write_feather(bfi_tib, glue('{d}{s}.feather',
-                                d = bfi_dir,
-                                s = sites[s]))
-    }
-
 }
 
 #tcw: STATUS=READY
@@ -1333,10 +1333,10 @@ process_3_ms819 <- function(network, domain, prodname_ms, site_code,
   dir <- glue('data/{n}/{d}/ws_traits/tcw/',
               n = network,
               d = domain)
-  
+
   tcw <- append_unprod_prefix(tcw, prodname_ms)
   tcw_final <- append_unprod_prefix(tcw_final, prodname_ms)
-  
+
   save_general_files(final_file = tcw_final,
                      raw_file = tcw,
                      domain_dir = dir)
@@ -1401,13 +1401,13 @@ process_3_ms820 <- function(network, domain, prodname_ms, site_code,
 
   final <- final %>%
     select(datetime, site_code, var, val)
-  
+
   final <- append_unprod_prefix(final, prodname_ms)
   final_sum <- append_unprod_prefix(final_sum, prodname_ms)
 
   dir <- glue('data/{n}/{d}/ws_traits/et_ref/',
               n = network, d = domain)
-  
+
   save_general_files(final_file = final_sum,
                      raw_file = final,
                      domain_dir = dir)

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -2617,9 +2617,11 @@ ms_munge <- function(network = domain,
     }
 }
 
-ms_general <- function(network=domain, domain){
-    source(glue('src/global/general.R', n=network, d=domain))
-    #return()
+ms_general <- function(network = domain, domain){
+
+    source(glue('src/global/general.R',
+                n = network,
+                d = domain))
 }
 
 ms_delineate <- function(network,
@@ -8760,20 +8762,20 @@ get_gee_standard <- function(network,
                              site_boundary,
                              batch = TRUE,
                              qa_band = NULL,
-                             bit_mask = NULL, 
+                             bit_mask = NULL,
                              contiguous_us = FALSE) {
-    
+
     if(contiguous_us){
         usa_bb <- sf::st_bbox(obj	= c(xmin = -124.725, ymin = 24.498, xmax = -66.9499,
                                       ymax = 49.384), crs = 4326) %>%
             sf::st_as_sfc(., crs = 4326)
-        
+
         is_usa <- ! length(sm(sf::st_intersects(usa_bb, site_boundary))[[1]]) == 0
-        
+
         if(! is_usa){
             return(NULL)
         }
-        
+
     }
     qaqc <- FALSE
     if(!is.null(qa_band) || !is.null(bit_mask)){
@@ -8785,14 +8787,14 @@ get_gee_standard <- function(network,
     }
 
     # area <- sf::st_area(site_boundary)
-    # 
+    #
     # sheds <- site_boundary %>%
     #     as.data.frame() %>%
     #     sf::st_as_sf() %>%
     #     select(site_code) %>%
     #     sf::st_transform(4326) %>%
     #     sf::st_set_crs(4326)
-    # 
+    #
     # site <- unique(sheds$site_code)
 
     #if(as.numeric(area) > 10528200 || batch){
@@ -8840,7 +8842,7 @@ get_gee_standard <- function(network,
                 }
                 if(i > 1){
                     one_ws <- ee$FeatureCollection(asset_path$ID[i])
-                    
+
                     ws_boundary_asset <- ws_boundary_asset$merge(one_ws)
                 }
             }
@@ -9033,8 +9035,8 @@ get_phonology <- function(network, domain, prodname_ms, time, site_boundary,
 
     year_files <- list.files(glue('data/spatial/phenology/{u}/{p}',
                              p = place,
-                             u = time)) 
-    
+                             u = time))
+
     if(length(year_files) == 0) {
         return(NULL)
     }
@@ -9785,10 +9787,6 @@ postprocess_entire_dataset <- function(site_data,
     log_with_indent('writing config datasets to local dir', logger = logger_module)
     write_portal_config_datasets()
 
-    log_with_indent('cataloging held data', logger = logger_module)
-    catalog_held_data(site_data = site_data,
-                      network_domain = network_domain)
-
     log_with_indent('combining watershed boundaries', logger = logger_module)
     combine_ws_boundaries()
 
@@ -9831,6 +9829,10 @@ postprocess_entire_dataset <- function(site_data,
                          dataset_version),
                     logger = logger_module)
     generate_output_dataset(vsn = dataset_version)
+
+    log_with_indent('cataloging held data', logger = logger_module)
+    catalog_held_data(site_data = site_data,
+                      network_domain = network_domain)
 
     # log_with_indent(glue('Removing unneeded files from portal dataset.',
     #                 logger = logger_module)
@@ -9925,8 +9927,30 @@ clean_portal_dataset <- function(){
 generate_output_dataset <- function(vsn){
 
     tryCatch({
+
+        # #find doesn't accept OR in globs. there is a way to do this though
+        # system(paste0('find data -path *derived/{*.feather,*.shx,*.shp,',
+        #           '*.prj,*.dbf} -printf %P\\\\0\\\\n | ',
+        #           'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+
+        #copy feathers to output dir
         system(paste0('find data -path "*derived/*.feather" -printf %P\\\\0\\\\n | ',
                   'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+
+        #copy shapefiles to output dir
+        system(paste0('find data -path "*derived/*.shp" -printf %P\\\\0\\\\n | ',
+                  'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+        system(paste0('find data -path "*derived/*.shx" -printf %P\\\\0\\\\n | ',
+                  'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+        system(paste0('find data -path "*derived/*.prj" -printf %P\\\\0\\\\n | ',
+                  'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+        system(paste0('find data -path "*derived/*.dbf" -printf %P\\\\0\\\\n | ',
+                  'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+
+        #copy documentation to output dir
+        system(paste0('find data -path "*derived/documentation*.txt" -printf %P\\\\0\\\\n | ',
+                  'rsync -av --files-from=- data macrosheds_dataset_v', vsn))
+
     }, error = function(e){
         stop(glue('generate_output_dataset can only run on a unix-like machine ',
                   'with `find` and `rsync` installed'),
@@ -9958,34 +9982,43 @@ generate_output_dataset <- function(vsn){
           find_dirs_within_outputdata(keyword = k, vsn = vsn))
     }
 
-    #collect pre-idw precip dirs (also intermediate products)
-    #that shouldn't be in the final dataset
-    pfpaths <- find_dirs_within_outputdata(keyword = 'precipitation__',
-                                           vsn = vsn)
+    #remove intermediate products that shouldn't be in the final dataset
+    for(k in c('precipitation', 'stream_chemistry', 'discharge')){
 
-    ppaths <- str_match(string = pfpaths,
-                        pattern = '(.*)?precipitation__ms[0-9]{3}$')[, 2] %>%
-        sort()
+        kfpaths <- find_dirs_within_outputdata(keyword = paste0(k, '__'),
+                                               vsn = vsn)
 
-    pfac <- factor(ppaths)
-    dirs_with_p_compprods <- as.character(pfac[duplicated(pfac)])
+        kpaths <- str_match(string = kfpaths,
+                            pattern = paste0('(.*)?/',
+                                             k))[, 2] %>%
+                                             # '__ms[0-9]{3}$'))[, 2] %>%
+            sort()
 
-    for(dr in dirs_with_p_compprods){
+        kfac <- factor(kpaths)
+        dirs_with_k_compprods <- as.character(kfac[duplicated(kfac)])
 
-        precip_dirs <- list.files(path = dr,
-                                  pattern = '^precipitation__')
+        for(dr in dirs_with_k_compprods){
 
-        if(length(precip_dirs) != 2){
-            stop('there should only be two precip dirs in consideration here')
+            k_dirs <- list.files(path = dr,
+                                 pattern = paste0('^', k, '__'))
+
+            if(length(k_dirs) != 2){
+                stop('there should only be two dirs in consideration here')
+            }
+
+            prodname_numeric <- str_match(string = k_dirs,
+                                          pattern = paste0(k, '__ms([0-9]{3})'))[, 2] %>%
+               as.numeric()
+
+            if(any(is.na(prodname_numeric))){
+                dir_to_delete_ind <- which(is.na(prodname_numeric))
+            } else {
+                dir_to_delete_ind <- which.min(prodname_numeric)
+            }
+
+            dirs_to_delete <- c(dirs_to_delete,
+                                file.path(dr, k_dirs[dir_to_delete_ind]))
         }
-
-        dir_to_delete_ind <- str_match(string = precip_dirs,
-                                       pattern = 'precipitation__ms([0-9]{3})')[, 2] %>%
-           as.numeric() %>%
-           which.min()
-
-        dirs_to_delete <- c(dirs_to_delete,
-                            paste0(dr, precip_dirs[dir_to_delete_ind]))
     }
 
     #drop em all from the final dataset
@@ -10706,15 +10739,17 @@ catalog_held_data <- function(network_domain, site_data){
 
     #TODO write full catalog for download using this code:
     #
-    # var_files <- dir('../portal/data/general/catalog_files/indiv_variables/')
+    # var_files <- dir('../portal/data/general/catalog_files/indiv_variables',
+    #                  full.names = TRUE)
     #
     # d_list <- list()
     # for(i in seq_along(var_files)){
     #
     #     f <- var_files[i]
-    #     var_name <- str_match(f, '^(.+)?\\.csv$')[, 2]
+    #     var_name <- str_match(f, '/([^/]+)?\\.csv$')[, 2]
     #
-    #     d_list[[i]] <- read_csv(f) %>%
+    #     d_list[[i]] <- read_csv(f,
+    #                             col_types = cols()) %>%
     #         mutate(Variable = !!var_name) %>%
     #         select(Variable, everything())
     # }
@@ -10724,30 +10759,40 @@ catalog_held_data <- function(network_domain, site_data){
     # write_csv(d, '/tmp/macrosheds_variable-by-site_summary.csv')
 
     nobs_nonspatial <- 0
-    # site_display <- tibble()
-    # site_vars <- tibble(network = character(),
-    #                     domain = character(),
-    #                     site = character(),
-    #                     stream = character(),
-    #                     lat = numeric(),
-    #                     long)
+
+    output_dataset <- paste0('macrosheds_dataset_v', vsn)
+    if(! dir.exists(output_dataset)){
+        stop('output dataset not yet generated')
+    }
 
     all_site_breakdown <- site_data %>%
-        filter(as.logical(in_workflow)) %>%
+        filter(as.logical(in_workflow),
+               ! site_type == 'rain_gauge') %>%
         select(-in_workflow, -notes, -CRS, -local_time_zone)
+
+    dup_inds_bool <- duplicated(site_data[, c('site_code', 'site_type')])
+    if(any(dup_inds_bool)){
+        dup_sites <- pull(site_data[dup_inds_bool, ], site_code)
+        stop(glue('Duplicate records in site_data: {dups}',
+                  dups = paste(dup_sites, collapse = ', ')))
+        #GSMACK, N01B, N02B have dupe site_codes, but for different site_types
+    }
 
     all_variable_breakdown <- tibble()
     for(i in 1:nrow(network_domain)){
 
-        site_prods <- list.dirs(glue('data/{n}/{d}/derived',
+        # site_prods <- list.dirs(glue('data/{n}/{d}/derived',
+        site_prods <- list.dirs(glue('{od}/{n}/{d}/derived',
+                                    od = output_dataset,
                                     n = network_domain$network[i],
                                     d = network_domain$domain[i]),
                                full.names = TRUE)
         site_prods <- site_prods[! grepl('derived$', site_prods)]
+        site_prods <- site_prods[! grepl('/documentation', site_prods)]
 
         if(length(site_prods) == 0) next
 
-        spatial_prod_inds <- grep(pattern = '(documentation|gauge|boundary)',
+        spatial_prod_inds <- grep(pattern = '(gauge|boundary)',
                                   x = site_prods)
 
         spatial_prods <- site_prods[spatial_prod_inds]
@@ -10756,7 +10801,7 @@ catalog_held_data <- function(network_domain, site_data){
         for(j in seq_along(nonspatial_prods)){
 
             if(any(grepl('precip_pchem_pflux', nonspatial_prods))){
-                logwarn(msg = 'why is there a precip_pchem_pflux directory?? fix this',
+                logwarn(msg = 'why is there a precip_pchem_pflux directory? fix this',
                         logger = logger_module)
                 nonspatial_prods <- nonspatial_prods[! grepl('precip_pchem_pflux', nonspatial_prods)]
             }
@@ -10805,11 +10850,25 @@ catalog_held_data <- function(network_domain, site_data){
                         prop_imputed = sum(ms_interp) / n_observations) %>%
                     ungroup() %>%
                     bind_rows(product_breakdown)
+
+                chem_vars <- ms_vars$variable_code[ms_vars$flux_convertible == 1]
+                is_chemvar <- product_breakdown$var %in% chem_vars
+
+                product_breakdown$chem_class <- 'NA'
+                if(grepl('stream_flux_inst_scaled', f)){
+                    product_breakdown$chem_class[is_chemvar] <- 'stream_flux'
+                } else if(grepl('precip_flux_inst_scaled', f)){
+                    product_breakdown$chem_class[is_chemvar] <- 'precip_flux'
+                } else if(grepl('precip_chemistry', f)){
+                    product_breakdown$chem_class[is_chemvar] <- 'precip_conc'
+                } else if(grepl('stream_chemistry', f)){
+                    product_breakdown$chem_class[is_chemvar] <- 'stream_conc'
+                }
             }
 
             #summarize and enhance goodies
             product_breakdown <- product_breakdown %>%
-                group_by(var, sample_regimen, site_code) %>%
+                group_by(var, sample_regimen, site_code, chem_class) %>%
                 summarize(
                     n_flagged = sum(prop_flagged * n_observations,
                                     na.rm = TRUE),
@@ -10834,11 +10893,11 @@ catalog_held_data <- function(network_domain, site_data){
                     sample_regimen == 'IN' ~ 'installed-nonsensor')) %>%
                 select(site_code, var, sample_regimen, n_observations,
                        first_record_UTC, last_record_UTC, pct_flagged,
-                       pct_imputed)
+                       pct_imputed, chem_class)
 
             #if multiple sample regimens for a site-variable, aggregate and append them as sample_regimen "all"
             product_breakdown <- product_breakdown %>%
-                group_by(site_code, var) %>%
+                group_by(site_code, var, chem_class) %>%
                 summarize(
                     n_observations = if(n() > 1) sum(n_observations, na.rm = TRUE) else first(n_observations),
                     pct_flagged = if(n() > 1) round(sum(pct_flagged, na.rm = TRUE), digits = 2) else first(pct_flagged),
@@ -10858,6 +10917,10 @@ catalog_held_data <- function(network_domain, site_data){
                 left_join(select(ms_vars,
                                  variable_code, variable_name, unit), #, method
                           by = c('var' = 'variable_code')) %>%
+                mutate(unit = ifelse(grepl('flux$',
+                                           chem_class),
+                                     'kg/ha/d',
+                                     unit)) %>%
                 left_join(select(all_site_breakdown,
                                  network, domain, site_code),
                           by = 'site_code') %>%
@@ -10866,6 +10929,7 @@ catalog_held_data <- function(network_domain, site_data){
                        site_code,
                        VariableCode = var,
                        VariableName = variable_name,
+                       ChemCategory = chem_class,
                        SampleRegimen = sample_regimen,
                        Unit = unit,
                        Observations = n_observations,
@@ -10873,7 +10937,8 @@ catalog_held_data <- function(network_domain, site_data){
                        LastRecordUTC = last_record_UTC,
                        PercentFlagged = pct_flagged,
                        PercentImputed = pct_imputed) %>%
-                arrange(network, domain, site_code, VariableCode, SampleRegimen) %>%
+                arrange(network, domain, site_code, VariableCode, ChemCategory,
+                        SampleRegimen) %>%
                 filter(! is.na(domain)) #only needed for unresolved Arctic naming issue (1/15/21)
 
             #combine with other product summaries
@@ -10888,10 +10953,27 @@ catalog_held_data <- function(network_domain, site_data){
     dir.create('../portal/data/general/catalog_files',
                showWarnings = FALSE)
 
-    #generate and write file describing all variables
+    ## generate and write file describing all variables
+
+    #chem and flux stuff is broken out by category, so summarize the vars that,
+    #aren't. otherwise they'd be duplicated (because they exist in multiple files),
+    #e.g. pH, spCond, d18O
+    all_variable_breakdown <- all_variable_breakdown %>%
+        group_by(network, domain, site_code, VariableCode, ChemCategory,
+                 SampleRegimen) %>%
+        summarize(VariableName = first(VariableName),
+                  Unit = first(Unit),
+                  FirstRecordUTC = min(FirstRecordUTC),
+                  LastRecordUTC = max(LastRecordUTC),
+                  PercentFlagged = sum(Observations * (PercentFlagged / 100)) /
+                      sum(Observations) * 100,
+                  PercentImputed = sum(Observations * (PercentImputed / 100)) /
+                      sum(Observations) * 100,
+                  Observations = sum(Observations),
+                  .groups = 'drop')
 
     all_variable_display <- all_variable_breakdown %>%
-        group_by(VariableCode) %>%
+        group_by(VariableCode, ChemCategory) %>%
         summarize(
             Observations = sum(Observations,
                                na.rm = TRUE),
@@ -10906,25 +10988,25 @@ catalog_held_data <- function(network_domain, site_data){
         mutate(MeanObsPerSite = round(Observations / Sites, 0),
                Availability = paste0("<button type='button' id='", VariableCode, "'>view</button>")) %>%
                # Availability = paste0("<a href='?", VariableCode, "'>view</a>")) %>%
-        select(Availability, VariableName, VariableCode, Unit, Observations, Sites,
-               MeanObsPerSite, FirstRecordUTC, LastRecordUTC)
+        select(Availability, VariableName, VariableCode, ChemCategory, Unit,
+               Observations, Sites, MeanObsPerSite, FirstRecordUTC,
+               LastRecordUTC)
 
     readr::write_csv(x = all_variable_display,
                      file = '../portal/data/general/catalog_files/all_variables.csv')
 
 
-    #generate and write individual file for each variable, describing it by site
+    ## generate and write individual file for each variable, describing it by site
 
     dir.create('../portal/data/general/catalog_files/indiv_variables',
                showWarnings = FALSE)
 
     vars <- unique(all_variable_display$VariableCode)
-
     for(v in vars){
 
         indiv_variable_display <- all_variable_breakdown %>%
             filter(VariableCode == !!v) %>%
-            group_by(network, domain, site_code) %>%
+            group_by(network, domain, site_code, ChemCategory) %>%
             summarize(
                 Observations = sum(Observations,
                                    na.rm = TRUE),
@@ -10953,17 +11035,21 @@ catalog_held_data <- function(network_domain, site_data){
             select(Network = pretty_network,
                    Domain = pretty_domain,
                    SiteCode = site_code,
-                   Unit, Observations, FirstRecordUTC, LastRecordUTC,
-                   MeanObsPerDay)
+                   ChemCategory, Unit, Observations, FirstRecordUTC,
+                   LastRecordUTC, MeanObsPerDay) %>%
+            arrange(Network, Domain, SiteCode, ChemCategory)
+
+        if(any(duplicated(indiv_variable_display[c('SiteCode', 'ChemCategory')]))){
+            stop("duplicated sites in indiv_variable_display. what's the deal?")
+        }
 
         readr::write_csv(x = indiv_variable_display,
                          file = glue('../portal/data/general/catalog_files/indiv_variables/',
                                      v, '.csv'))
     }
 
-    #generate and write file describing all sites
-    #TODO: make sure to include a note about datum on display page
-    #   also, incude url column somehow
+    ## generate and write file describing all sites
+    #TODO: ExternalLink column
 
     all_site_display <- all_variable_breakdown %>%
         group_by(network, domain, site_code) %>%
@@ -10980,7 +11066,8 @@ catalog_held_data <- function(network_domain, site_data){
                ExternalLink = 'feature not yet built',
                Availability = paste0("<button type='button' id='",
                                      network, '_', domain, '_', site_code,
-                                     "'>view</button>")) %>%
+                                     "'>view</button>"),
+               GeodeticDatum = 'WGS 84') %>%
         left_join(all_site_breakdown,
                   by = c('network', 'domain', 'site_code')) %>%
         select(Availability,
@@ -10991,6 +11078,7 @@ catalog_held_data <- function(network_domain, site_data){
                StreamName = stream,
                Latitude = latitude,
                Longitude = longitude,
+               GeodeticDatum,
                SiteType = site_type,
                AreaHectares = ws_area_ha,
                Observations, Variables, FirstRecordUTC, LastRecordUTC,
@@ -10999,7 +11087,7 @@ catalog_held_data <- function(network_domain, site_data){
     readr::write_csv(x = all_site_display,
                      file = '../portal/data/general/catalog_files/all_sites.csv')
 
-    #generate and write individual file for each site, describing it by variable
+    ## generate and write individual file for each site, describing it by variable
 
     dir.create('../portal/data/general/catalog_files/indiv_sites',
                showWarnings = FALSE)
@@ -11033,9 +11121,13 @@ catalog_held_data <- function(network_domain, site_data){
             #                  domain, pretty_domain, network, pretty_network,
             #                  site_code),
             #           by = c('network', 'domain', 'site_code')) %>%
-            select(VariableCode, VariableName, SampleRegimen, Unit,
+            select(VariableCode, VariableName, ChemCategory, SampleRegimen, Unit,
                    Observations, FirstRecordUTC, LastRecordUTC,
                    MeanObsPerDay, PercentFlagged, PercentImputed)
+
+        if(any(duplicated(indiv_site_display[c('VariableCode', 'ChemCategory', 'SampleRegimen')]))){
+            stop("duplicated vars in indiv_site_display. what's the deal?")
+        }
 
         readr::write_csv(x = indiv_site_display,
                          file = glue('../portal/data/general/catalog_files/indiv_sites/',
@@ -12979,13 +13071,13 @@ append_unprod_prefix <- function(d, prodname_ms){
 }
 
 save_general_files <- function(final_file, raw_file, domain_dir){
-    
+
     dir.create(domain_dir, recursive = TRUE, showWarnings = FALSE)
-    
+
     raw_exists <- ! missing(raw_file)
     sites <- unique(final_file$site_code)
     for(s in 1:length(sites)){
-        
+
         final_file_site <- filter(final_file, site_code == !!sites[s])
 
         sum_path <- glue('{d}sum_{s}.feather',
@@ -12993,7 +13085,7 @@ save_general_files <- function(final_file, raw_file, domain_dir){
                          s = sites[s])
 
         write_feather(final_file_site, sum_path)
-        
+
         if(raw_exists){
             raw_file_site <- filter(raw_file, site_code == !!sites[s])
 
@@ -13002,7 +13094,7 @@ save_general_files <- function(final_file, raw_file, domain_dir){
                              s = sites[s])
 
             write_feather(raw_file_site, raw_path)
-            
+
         }
     }
 }

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -1,6 +1,6 @@
 #functions without the "#. handle_errors" decorator have special error handling
 
-handle_errors = function(f){
+handle_errors <- function(f){
 
     #decorator function. takes any function as argument and executes it.
     #if error occurs within passed function, combines error message and
@@ -1763,40 +1763,50 @@ get_all_local_helpers <- function(network, domain){
     #because it can only read them into the current environment, all files
     #sourced by this function are exported locally, then exported globally
 
-    location1 = glue('src/{n}/network_helpers.R', n=network)
+    location1 <- glue('src/{n}/network_helpers.R',
+                      n = network)
+
     if(file.exists(location1)){
 
-        sw(source(location1, local=TRUE))
+        sw(source(location1, local = TRUE))
 
         if(ms_instance$use_ms_error_handling){
             sw(source_decoratees(location1))
         }
     }
 
-    location2 = glue('src/{n}/{d}/domain_helpers.R', n=network, d=domain)
+    location2 <- glue('src/{n}/{d}/domain_helpers.R',
+                      n = network,
+                      d = domain)
+
     if(file.exists(location2)){
 
-        sw(source(location2, local=TRUE))
+        sw(source(location2, local = TRUE))
 
         if(ms_instance$use_ms_error_handling){
             sw(source_decoratees(location2))
         }
     }
 
-    location3 = glue('src/{n}/processing_kernels.R', n=network)
+    location3 <- glue('src/{n}/processing_kernels.R',
+                      n = network)
+
     if(file.exists(location3)){
 
-        sw(source(location3, local=TRUE))
+        sw(source(location3, local = TRUE))
 
         if(ms_instance$use_ms_error_handling){
             sw(source_decoratees(location3))
         }
     }
 
-    location4 = glue('src/{n}/{d}/processing_kernels.R', n=network, d=domain)
+    location4 <- glue('src/{n}/{d}/processing_kernels.R',
+                      n = network,
+                      d = domain)
+
     if(file.exists(location4)){
 
-        sw(source(location4, local=TRUE))
+        sw(source(location4, local = TRUE))
 
         if(ms_instance$use_ms_error_handling){
             sw(source_decoratees(location4))
@@ -1805,10 +1815,8 @@ get_all_local_helpers <- function(network, domain){
 
     rm(location1, location2, location3, location4)
 
-    export_to_global(from_env=environment(),
-                     exclude=c('network', 'domain', 'thisenv'))
-
-    #return()
+    export_to_global(from_env = environment(),
+                     exclude = c('network', 'domain', 'thisenv'))
 }
 
 set_up_logger <- function(network = domain, domain){
@@ -9291,7 +9299,7 @@ compute_download_filesizes <- function(){
                recursive = TRUE)
 
     dmn_dirs <- list.files('../portal/data/')
-    dmn_dirs <- dmn_dirs[! dmn_dirs == c('general', 'all_ws_bounds', 'all_ws_bounds.zip')]
+    dmn_dirs <- dmn_dirs[! dmn_dirs %in% c('general', 'all_ws_bounds', 'all_ws_bounds.zip')]
 
     dmn_dl_size <- data.frame(domain = dmn_dirs,
                               dl_size_MB = NA_character_)
@@ -10555,6 +10563,25 @@ retrieve_versionless_product <- function(network,
                               set_details = deets,
                               new_status = new_status)
 
+        if(ms_instance$use_ms_error_handling){
+
+            kernel_funcs <- glue('src/{n}/processing_kernels.R',
+                                 n = network)
+
+            if(! file.exists(kernel_funcs)){
+
+                kernel_funcs <- glue('src/{n}/{d}/processing_kernels.R',
+                                     n = network,
+                                     d = domain)
+            }
+
+            source(kernel_funcs,
+                   local = TRUE)
+
+            processing_func <- get(paste0('process_0_',
+                                   prodcode_from_prodname_ms(prodname_ms)))
+        }
+
         source_urls <- get_source_urls(result_obj = result,
                                        processing_func = processing_func)
 
@@ -10652,6 +10679,25 @@ catalog_held_data <- function(network_domain, site_data){
     # + informational catalog for all sites
     # + informational catalog for each individual variable
     # + informational catalog for each individual site
+
+    #TODO write full catalog for download using this code:
+    #
+    # var_files <- dir('../portal/data/general/catalog_files/indiv_variables/')
+    #
+    # d_list <- list()
+    # for(i in seq_along(var_files)){
+    #
+    #     f <- var_files[i]
+    #     var_name <- str_match(f, '^(.+)?\\.csv$')[, 2]
+    #
+    #     d_list[[i]] <- read_csv(f) %>%
+    #         mutate(Variable = !!var_name) %>%
+    #         select(Variable, everything())
+    # }
+    #
+    # d <- Reduce(bind_rows, d_list)
+    #
+    # write_csv(d, '/tmp/macrosheds_variable-by-site_summary.csv')
 
     nobs_nonspatial <- 0
     # site_display <- tibble()
@@ -11250,6 +11296,7 @@ insert_gap_border_NAs <- function(network_domain, site_data){
                         full.names = TRUE)
 
     paths <- paths[! grepl(pattern = '/general/', x = paths)]
+    paths <- paths[! grepl(pattern = '/ws_traits/', x = paths)]
 
     for(p in paths){
 

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -2617,15 +2617,11 @@ ms_general <- function(network=domain, domain){
 ms_delineate <- function(network,
                          domain,
                          dev_machine_status,
-                         sites_from_gdrive,
                          verbose = FALSE){
 
     #dev_machine_status: either '1337', indicating that your machine has >= 16 GB
     #   RAM, or 'n00b', indicating < 16 GB RAM. DEM resolution is chosen
     #   accordingly. passed to delineate_watershed_apriori
-    #sites_from_gdrive: a list. names are domains and values are vectors of
-    #   site_codes. corresponding watershed boundaries will be downloaded from
-    #   google drive.
     #verbose: logical. determines the amount of informative messaging during run
 
     loginfo(msg = 'Beginning watershed delineation',
@@ -2723,21 +2719,6 @@ ms_delineate <- function(network,
 
         dir.create(site_dir,
                    showWarnings = FALSE)
-
-        if(site %in% sites_from_gdrive[[domain]]){
-
-            download_from_gdrive_arbitrary(network = network,
-                                           domain = domain,
-                                           site_code = site,
-                                           prodname_ms = ws_boundary_dir,
-                                           level = level)
-
-            loginfo(glue('Retrieved {s} boundary from gdrive',
-                         s = site),
-                    logger = logger_module)
-
-            next
-        }
 
         specs <- ws_delin_specs %>%
             filter(
@@ -11999,18 +11980,18 @@ download_from_googledrive <- function(set_details, network, domain){
 
         needed_files <- drive_files[! drive_files %in% held_files]
 
-        prod_files_neeed <- prod_files %>%
+        prod_files_need <- prod_files %>%
             filter(name %in% needed_files)
 
-        for(i in 1:nrow(prod_files_neeed)){
+        for(i in 1:nrow(prod_files_need)){
 
             raw_file_path <- glue('{rd}/{n}',
                                   rd = raw_data_dest,
-                                  n = prod_files_neeed$name[i])
+                                  n = prod_files_need$name[i])
 
             status <- expo_backoff(
                 expr = {
-                    googledrive::drive_download(file = googledrive::as_id(prod_files_neeed$id[i]),
+                    googledrive::drive_download(file = googledrive::as_id(prod_files_need$id[i]),
                                                 path = raw_file_path,
                                                 overwrite = TRUE)
                 },

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -11066,8 +11066,8 @@ catalog_held_data <- function(network_domain, site_data){
                ExternalLink = 'feature not yet built',
                Availability = paste0("<button type='button' id='",
                                      network, '_', domain, '_', site_code,
-                                     "'>view</button>"),
-               GeodeticDatum = 'WGS 84') %>%
+                                     "'>view</button>")) %>%
+               # GeodeticDatum = 'WGS 84') %>%
         left_join(all_site_breakdown,
                   by = c('network', 'domain', 'site_code')) %>%
         select(Availability,
@@ -11078,7 +11078,7 @@ catalog_held_data <- function(network_domain, site_data){
                StreamName = stream,
                Latitude = latitude,
                Longitude = longitude,
-               GeodeticDatum,
+               # GeodeticDatum,
                SiteType = site_type,
                AreaHectares = ws_area_ha,
                Observations, Variables, FirstRecordUTC, LastRecordUTC,
@@ -12606,13 +12606,10 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
     for(i in 1:nrow(df)) {
 
         dom <- df$domain[i]
-
         net <- df$network[i]
 
         dom_path <- glue('../portal/data/{d}/stream_chemistry/', d = dom)
-
         site_files <- list.files(dom_path)
-
         sites <- str_split_fixed(site_files, pattern = '[.]', n = 2)[,1]
 
         stream_sites <- site_data %>%
@@ -12622,12 +12619,9 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
             pull(site_code)
 
         all_sites <- tibble()
+        if(length(stream_sites) > 0){
 
-        if(length(stream_sites) == 0) {
-
-        } else{
-
-            for(p in 1:length(stream_sites)) {
+            for(p in 1:length(stream_sites)){
 
                 path_chem <- glue("../portal/data/{d}/stream_chemistry/{s}.feather",
                                   d = dom,
@@ -12653,8 +12647,8 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
                                          d = dom,
                                          s = stream_sites[p])
 
-                #Stream discharge ####
-                if(!file.exists(path_q)) {
+                #Stream discharge
+                if(! file.exists(path_q)){
                     site_q <- tibble()
                     q_record_length <- 365
                 } else {
@@ -12703,7 +12697,7 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
 
                 all_sites <- rbind(all_sites, site_q)
 
-                #Stream chemistry concentration ####
+                #Stream chemistry concentration
                 if(!file.exists(path_chem)) {
                     site_chem <- tibble()
                 } else {
@@ -12748,7 +12742,7 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
 
                 all_sites <- rbind(all_sites, site_chem)
 
-                #Stream chemistry flux ####
+                #Stream chemistry flux
                 if(!file.exists(path_flux)) {
                     site_flux <- tibble()
                 } else {
@@ -12792,7 +12786,7 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
 
                 all_sites <- rbind(all_sites, site_flux)
 
-                #Precipitation ####
+                #Precipitation
                 if(!file.exists(path_precip)) {
                     site_precip <- tibble()
                 } else {
@@ -12831,7 +12825,7 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
 
                 all_sites <- rbind(all_sites, site_precip)
 
-                #Precipitation chemistry concentration ####
+                #Precipitation chemistry concentration
                 if(!file.exists(path_precip_chem)) {
                     site_precip_chem <- tibble()
                 } else {
@@ -12873,7 +12867,7 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
 
                 all_sites <- rbind(all_sites, site_precip_chem)
 
-                #Precipitation chemistry flux ####
+                #Precipitation chemistry flux
                 if(!file.exists(path_precip_flux)) {
                     site_precip_flux <- tibble()
                 } else {
@@ -12947,9 +12941,8 @@ compute_yearly_summary <- function(filter_ms_interp = FALSE,
     }
 }
 
-compute_yearly_summary_ws <- function() {
+compute_yearly_summary_ws <- function(){
 
-    #df = default sites for each domain
     df <- site_data %>%
         group_by(network, domain) %>%
         summarize(site_code = first(site_code),
@@ -12969,13 +12962,13 @@ compute_yearly_summary_ws <- function() {
                          d = dom)
 
         prod_files <- list.files(dom_path,
-                                 full.names = T,
-                                 recursive = T)
+                                 full.names = TRUE,
+                                 recursive = TRUE)
 
         prod_files <- prod_files[! grepl('raw_', prod_files)]
 
         all_prods <- tibble()
-        if(! length(prod_files) == 0){
+        if(length(prod_files) > 0){
 
             for(p in 1:length(prod_files)) {
 
@@ -13007,8 +13000,10 @@ compute_yearly_summary_ws <- function() {
     all_domain <- all_domain %>%
         filter(var %in% !!ws_vars_keep)
 
-    summary_file_paths <- grep('year', list.files('../portal/data/general/biplot',
-                                                  full.names = TRUE), value = T)
+    summary_file_paths <- grep('year',
+                               list.files('../portal/data/general/biplot',
+                                          full.names = TRUE),
+                               value = TRUE)
 
     for(s in 1:length(summary_file_paths)){
 

--- a/src/krycklan/krycklan/products.csv
+++ b/src/krycklan/krycklan/products.csv
@@ -1,13 +1,13 @@
 prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,components
-VERSIONLESS001,discharge,ready,ready,NA,stream_flux_inst__ms001,NA,NA
-VERSIONLESS002,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms002,NA,NA
+VERSIONLESS001,discharge,ready,ready,NA,stream_flux_inst__ms002,NA,NA
+VERSIONLESS002,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms004,NA,NA
 VERSIONLESS003,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA,NA
 VERSIONLESS004,stream_temperature,ready,ready,NA,stream_chemistry__ms001,NA,NA
-VERSIONLESS005,ws_boundary,ready,ready,NA,NA,NA,NA
-VERSIONLESS006,precipitation,ready,ready,NA,precip_pchem_pflux__ms002,NA,NA
-ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms001,NA,NA
+VERSIONLESS005,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms004,NA,NA
+VERSIONLESS006,precipitation,ready,ready,NA,precip_pchem_pflux__ms004,NA,NA
+ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms002,NA,NA
 ms002,stream_flux_inst,NA,NA,ready,NA,NA,NA
-ms003,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms002,NA,NA
+ms003,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms004,NA,NA
 ms004,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
 ms005,discharge,NA,NA,linked,NA,automated entry,NA
 ms006,ws_boundary,NA,NA,linked,NA,automated entry,NA

--- a/src/lter/hbef/processing_kernels.R
+++ b/src/lter/hbef/processing_kernels.R
@@ -272,7 +272,8 @@ process_1_94 <- function(network, domain, prodname_ms, site_code,
     wb <- sf::st_read(rawdir, stringsAsFactors = FALSE,
                       quiet = TRUE) %>%
         # mutate(WSHEDS0_ID = ifelse(is.na(WSHEDS0_ID), 0, WSHEDS0_ID)) %>%
-        filter(!is.na(WS)) %>% #ignore encompassing, non-experimental watershed
+        filter(! is.na(WS), #ignore encompassing, non-experimental watershed
+               site_code != 'w101') %>% #and ungauged w101
         select(site_code = WSHEDS0_ID,
                area = AREA,
                perimeter = PERIMETER,

--- a/src/lter/network_helpers.R
+++ b/src/lter/network_helpers.R
@@ -14,20 +14,21 @@ ms_pasta_domain_refmap = list(
 
 get_latest_product_version <- function(prodname_ms, domain, data_tracker){
 
-    vsn_endpoint = 'https://pasta.lternet.edu/package/eml/'
+    vsn_endpoint <- 'https://pasta.lternet.edu/package/eml/'
 
-    domain_ref = ms_pasta_domain_refmap[[domain]]
-    prodcode = prodcode_from_prodname_ms(prodname_ms=prodname_ms)
+    domain_ref <- ms_pasta_domain_refmap[[domain]]
+    prodcode <- prodcode_from_prodname_ms(prodname_ms = prodname_ms)
 
-    vsn_request = glue(vsn_endpoint, domain_ref, '/', prodcode)
+    vsn_request <- glue(vsn_endpoint, domain_ref, '/', prodcode)
 
     if(ms_instance$op_system == 'windows'){
         newest_vsn <- xml2::xml_text(xml2::read_html(vsn_request))
     } else{
-        newest_vsn <- RCurl::getURLContent(vsn_request, timeout=10)
+        newest_vsn <- RCurl::getURLContent(vsn_request,
+                                           timeout = 10)
     }
 
-    newest_vsn = as.numeric(stringr::str_match(newest_vsn,
+    newest_vsn <- as.numeric(stringr::str_match(newest_vsn,
         '[0-9]+$')[1])
 
     return(newest_vsn)

--- a/src/lter/plum/munge.R
+++ b/src/lter/plum/munge.R
@@ -3,7 +3,8 @@ loginfo('Beginning munge', logger=logger_module)
 prod_info <- get_product_info(network = network,
                              domain = domain,
                              status_level = 'munge',
-                             get_statuses = 'ready')
+                             get_statuses = 'ready') %>%
+    filter(! grepl('^VERSIONLESS', prodcode))
 
 if(! is.null(prodname_filter)){
     prod_info <- filter(prod_info, prodname %in% prodname_filter)

--- a/src/lter/plum/munge_versionless.R
+++ b/src/lter/plum/munge_versionless.R
@@ -1,0 +1,82 @@
+
+loginfo('Beginning munge (versionless products)',
+        logger = logger_module)
+
+prod_info <- get_product_info(network = network,
+                              domain = domain,
+                              status_level = 'munge',
+                              get_statuses = 'ready') %>%
+    filter(grepl(pattern = '^VERSIONLESS',
+                 x = prodcode))
+
+if(! is.null(prodname_filter)){
+    prod_info <- filter(prod_info, prodname %in% prodname_filter)
+}
+
+if(nrow(prod_info) == 0) return()
+
+for(i in seq_len(nrow(prod_info))){
+
+    prodname_ms <<- paste0(prod_info$prodname[i], '__', prod_info$prodcode[i])
+
+    held_data <<- get_data_tracker(network=network, domain=domain)
+
+    if(! product_is_tracked(held_data, prodname_ms)){
+
+        logwarn(glue('Product {p} is not yet tracked. Retrieve ',
+                     'it before munging it.',
+                     p = prodname_ms),
+                logger = logger_module)
+        next
+    }
+
+    sites <- names(held_data[[prodname_ms]])
+
+    for(j in 1:length(sites)){
+
+        site_code <- sites[j]
+
+        munge_status <- get_munge_status(tracker = held_data,
+                                         prodname_ms = prodname_ms,
+                                         site_code = site_code)
+
+        if(munge_status == 'ok'){
+
+            loginfo(glue('Nothing to do for {s} {p}',
+                         s = site_code,
+                         p = prodname_ms),
+                    logger = logger_module)
+            next
+
+        } else {
+            loginfo(glue('Munging {s} {p}',
+                         s = site_code,
+                         p = prodname_ms),
+                    logger = logger_module)
+        }
+
+        munge_rtn <- munge_versionless_product(
+            network = network,
+            domain = domain,
+            prodname_ms = prodname_ms,
+            site_code = sites[j],
+            tracker = held_data)
+
+        if(is_ms_err(munge_rtn)){
+            update_data_tracker_m(network = network,
+                                  domain = domain,
+                                  tracker_name = 'held_data',
+                                  prodname_ms = prodname_ms,
+                                  site_code = sites[j],
+                                  new_status = 'error')
+
+        } else {
+            invalidate_derived_products(successor_string = prod_info$precursor_of[i])
+        }
+    }
+
+    gc()
+}
+
+loginfo('Munge complete for all versionless products',
+        logger = logger_module)

--- a/src/lter/plum/processing_kernels.R
+++ b/src/lter/plum/processing_kernels.R
@@ -418,6 +418,10 @@ process_0_496 <- retrieve_plum
 #. handle_errors
 process_0_542 <- retrieve_plum
 
+#ws_boundary: STATUS=READY
+#. handle_errors
+process_0_VERSIONLESS001 <- download_from_googledrive
+
 #munge kernels ####
 
 #stream_chemistry: STATUS=READY
@@ -1124,6 +1128,31 @@ process_1_496 <- munge_precip_alt
 #precipitation: STATUS=READY
 #. handle_errors
 process_1_542 <- munge_precip_alt
+
+#ws_boundary: STATUS=READY
+#. handle_errors
+process_1_VERSIONLESS001 <- function(network, domain, prodname_ms, site_code, component) {
+
+    rawfile <- glue('data/{n}/{d}/raw/ws_boundary__VERSIONLESS001/sitename_NA/cart_creek.zip',
+                    n = network,
+                    d = domain)
+
+    mungedir <- glue('data/{n}/{d}/munged/ws_boundary__VERSIONLESS001/',
+                     n = network,
+                     d = domain)
+
+    unzip(rawfile,
+          exdir = mungedir)
+
+    sf::st_read(dsn = file.path(mungedir, 'cart_creek')) %>%
+        sf::st_transform(4326) %>%
+        rename(site_code = site_name) %>%
+        sf::st_write(dsn = file.path(mungedir, 'cart_creek'),
+                     driver = 'ESRI shapefile',
+                     delete_dsn = TRUE)
+
+    return()
+}
 
 #derive kernels ####
 

--- a/src/lter/plum/products.csv
+++ b/src/lter/plum/products.csv
@@ -1,4 +1,4 @@
-prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,X8
+prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,components
 109,stream_chemistry,ready,ready,NA,stream_chemistry__ms002,fish brook 2001,"stage, temp, cond, DO, pH"
 110,stream_chemistry,ready,ready,NA,stream_chemistry__ms002,fish brook 2002,"stage, temp, cond, DO, pH"
 111,discharge,ready,ready,NA,discharge__ms001,Cart cr 2001,"stage, temp, cond, DO, pH"
@@ -131,6 +131,7 @@ prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes,
 423,precipitation,ready,ready,NA,precipitation__ms003,MBL Marshview 2017,NA
 496,precipitation,ready,ready,NA,precipitation__ms003,MBL Marshview 2018,NA
 542,precipitation,ready,ready,NA,precipitation__ms003,MBL Marshview 2019,NA
+VERSIONLESS001,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms008,NA,NA
 ms004,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms008,NA,NA
 ms006,stream_gauge_locations,NA,NA,ready,NA,NA,NA
 ms001,discharge,NA,NA,ready,stream_flux_inst__ms005,NA,NA
@@ -140,3 +141,4 @@ ms005,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms008,precip_pchem_pflux,NA,NA,ready,NA,NA,NA
 ms000,ws_boundary,NA,NA,NA,precip_pchem_pflux__ms008,automated entry,NA
 ms900,precipitation,NA,NA,NA,NA,automated entry,NA
+ms009,ws_boundary,NA,NA,linked,NA,automated entry,NA

--- a/src/lter/plum/retrieve.R
+++ b/src/lter/plum/retrieve.R
@@ -1,9 +1,10 @@
 loginfo('Beginning retrieve', logger=logger_module)
 
-prod_info <- get_product_info(network = network, 
+prod_info <- get_product_info(network = network,
                              domain = domain,
-                             status_level = 'retrieve', 
-                             get_statuses = 'ready')
+                             status_level = 'retrieve',
+                             get_statuses = 'ready') %>%
+    filter(! grepl('^VERSIONLESS', prodcode))
 
 if(! is.null(prodname_filter)){
     prod_info <- filter(prod_info, prodname %in% prodname_filter)
@@ -28,7 +29,7 @@ for(i in seq_len(nrow(prod_info))){
         version=latest_vsn, domain=domain, data_tracker=held_data)
 
     if(is_ms_err(avail_sets)) next
-    
+
     avail_sets <- avail_sets %>%
         filter(!grepl('xlx|xls', component))
 

--- a/src/lter/plum/retrieve_versionless.R
+++ b/src/lter/plum/retrieve_versionless.R
@@ -1,0 +1,84 @@
+
+loginfo('Beginning retrieve (versionless products)',
+        logger = logger_module)
+
+prod_info <- get_product_info(network = network,
+                              domain = domain,
+                              status_level = 'retrieve',
+                              get_statuses = 'ready') %>%
+    filter(grepl(pattern = '^VERSIONLESS',
+                 x = prodcode))
+
+if(! is.null(prodname_filter)){
+    prod_info <- filter(prod_info, prodname %in% prodname_filter)
+}
+
+if(nrow(prod_info) == 0) return()
+
+site_code <- 'sitename_NA'
+
+for(i in seq_len(nrow(prod_info))){
+
+    prodcode <- prod_info$prodcode[i]
+
+    prodname_ms <<- paste0(prod_info$prodname[i],
+                           '__',
+                           prodcode)
+
+    held_data <<- get_data_tracker(network = network,
+                                   domain = domain)
+
+    if(! product_is_tracked(tracker = held_data,
+                            prodname_ms = prodname_ms)){
+
+        held_data <<- track_new_product(tracker = held_data,
+                                        prodname_ms = prodname_ms)
+    }
+
+    if(! site_is_tracked(tracker = held_data,
+                         prodname_ms = prodname_ms,
+                         site_code = site_code)){
+
+        held_data <<- insert_site_skeleton(
+            tracker = held_data,
+            prodname_ms = prodname_ms,
+            site_code = site_code,
+            site_components = prod_info$components[i],
+            versionless = TRUE
+        )
+    }
+
+    update_data_tracker_r(network = network,
+                          domain = domain,
+                          tracker = held_data)
+
+    dest_dir <- glue('data/{n}/{d}/raw/{p}/{s}',
+                     n = network,
+                     d = domain,
+                     p = prodname_ms,
+                     s = site_code)
+
+    dir.create(path = dest_dir,
+               showWarnings = FALSE,
+               recursive = TRUE)
+
+    retrieve_versionless_product(network = network,
+                                 domain = domain,
+                                 prodname_ms = prodname_ms,
+                                 site_code = site_code,
+                                 tracker = held_data)
+
+    if(! is.na(prod_info$munge_status[i])){
+        update_data_tracker_m(network = network,
+                              domain = domain,
+                              tracker_name = 'held_data',
+                              prodname_ms = prodname_ms,
+                              site_code = site_code,
+                              new_status = 'pending')
+    }
+
+    gc()
+}
+
+loginfo('Retrieval complete for all versionless products',
+        logger = logger_module)

--- a/src/neon/neon/munge.R
+++ b/src/neon/neon/munge.R
@@ -65,6 +65,11 @@ for(i in seq_len(nrow(prod_info))){
         }
     }
 
+    write_metadata_m(network = network,
+                     domain = domain,
+                     prodname_ms = prodname_ms,
+                     tracker = held_data)
+
     gc()
 }
 

--- a/src/neon/neon/processing_kernels.R
+++ b/src/neon/neon/processing_kernels.R
@@ -333,7 +333,7 @@ process_0_VERSIONLESS001 <- function(set_details, network, domain){
         as.POSIXct() %>%
         with_tz('UTC')
 
-    deets_out <- list(url = NA_character_,
+    deets_out <- list(url = url,
                       access_time = NA_character_,
                       last_mod_dt = NA_character_)
 

--- a/src/neon/neon/products.csv
+++ b/src/neon/neon/products.csv
@@ -15,9 +15,9 @@ DP1.20097,stream_gases,paused,paused,NA,stream_chemistry__ms001,NA
 DP1.20016,surface_elevation,paused,paused,NA,NA,NA
 DP1.20053,stream_temperature,paused,paused,NA,stream_chemistry__ms001,NA
 DP1.20042,stream_PAR,paused,paused,NA,NA,NA
-DP1.00006,precipitation,ready,ready,NA,precip_pchem_pflux__ms002,NA
-DP1.00013,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms002,NA
-VERSIONLESS001,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms002,NA
+DP1.00006,precipitation,ready,ready,NA,precipitation__ms002,NA
+DP1.00013,precip_chemistry,ready,ready,NA,precip_flux_inst__ms003,NA
+VERSIONLESS001,ws_boundary,ready,ready,NA,precip_flux_inst__ms003,NA
 ms001,stream_chemistry,NA,NA,ready,stream_flux_inst__ms004,NA
 ms002,precipitation,NA,NA,ready,precip_flux_inst__ms003,NA
 ms003,precip_flux_inst,NA,NA,ready,NA,NA

--- a/src/neon/neon/products.csv
+++ b/src/neon/neon/products.csv
@@ -1,6 +1,6 @@
 prodcode,prodname,retrieve_status,munge_status,derive_status,precursor_of,notes
 DP1.20093,stream_chemistry,ready,ready,NA,stream_chemistry__ms001,NA
-DP1.20288,stream_quality,ready,paused,NA,stream_chemistry__ms001,NA
+DP1.20288,stream_quality,paused,paused,NA,stream_chemistry__ms001,NA
 DP?.20267,gageht,paused,pending,NA,NA,verify DP#
 DP?.00133,zqcurve,paused,pending,NA,NA,verify DP#
 DP4.00130,discharge,ready,ready,NA,stream_flux_inst__ms004,NA

--- a/src/neon/neon/retrieve.R
+++ b/src/neon/neon/retrieve.R
@@ -107,6 +107,11 @@ for(i in seq_len(nrow(prod_info))){
         }
     }
 
+    write_metadata_r(murl = 'data.neonscience.org (downloaded via neonUtilities)',
+                     network = network,
+                     domain = domain,
+                     prodname_ms = prodname_ms)
+
     gc()
 }
 

--- a/src/neon/neon/retrieve_versionless.R
+++ b/src/neon/neon/retrieve_versionless.R
@@ -120,7 +120,6 @@ for(i in seq_len(nrow(prod_info))){
                               site_code = site_code,
                               new_status = 'pending')
     }
-    # }
 
     gc()
 }

--- a/src/templates/write_metadata_d_boilerplate.txt
+++ b/src/templates/write_metadata_d_boilerplate.txt
@@ -18,7 +18,7 @@ Using these notes, our code on GitHub, and assuming you have a good bit of R pro
 you will ideally be able to piece together exactly how {p} was generated and regenerate it yourself.
 That said, automated documentation like this is bound to have some errors and missing details until
 we get all the kinks worked out, and in any case assembling all the code below into a usable script
-won't be an easy task. Please contact us at help@macrosheds.org if you're having trouble
+won't be an easy task. Please contact us at mail@macrosheds.org if you're having trouble
 navigating our docs.
 
 Below you will find the "derive kernel" function(s) by which {p} was generated.

--- a/src/templates/write_metadata_d_linkprod_boilerplate.txt
+++ b/src/templates/write_metadata_d_linkprod_boilerplate.txt
@@ -18,7 +18,7 @@ Using these notes, our code on GitHub, and assuming you have a good bit of R pro
 you will ideally be able to piece together exactly how {p} was generated and regenerate it yourself.
 That said, automated documentation like this is bound to have some errors and missing details until
 we get all the kinks worked out, and in any case assembling all the code below into a usable script
-won't be an easy task. Please contact us at help@macrosheds.org if you're having trouble
+won't be an easy task. Please contact us at mail@macrosheds.org if you're having trouble
 navigating our docs.
 
 {mb}

--- a/src/usfs/santee/products.csv
+++ b/src/usfs/santee/products.csv
@@ -3,7 +3,7 @@ VERSIONLESS001,precipitation,ready,ready,NA,precip_pchem_pflux__ms003,NA,precip
 VERSIONLESS002,discharge,ready,ready,NA,stream_flux_inst__ms001,NA,discharge
 VERSIONLESS003,stream_chemistry,ready,ready,NA,stream_flux_inst__ms001,NA,stream_chem
 VERSIONLESS004,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms003,NA,precip_chem
-VERSIONLESS005,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms003,NA,NA
+VERSIONLESS005,ws_boundary,ready,pending,NA,precip_pchem_pflux__ms003,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms002,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms003,NA,NA
 ms003,precip_pchem_pflux,NA,NA,ready,NA,NA,NA


### PR DESCRIPTION
@spencerrhea bounds_from_gdrive is gone, and plum has new versionless kernels for cart_creek boundary. Two things to note:

I replaced `str_split_fixed` with `str_match` in  process_1_VERSIONLESS009. I was getting an error because of the differences in how windows and unix-like machines define paths, so this regex works from the end of the path string, ignoring the system-specific idiosynchrasies at the beginning.

When you add or change products in a products.csv file, be sure to update the precursor_of column. 