### PR TITLE
Santee, ws area change, ws101 removed

### DIFF
--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -239,7 +239,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow = 16
+# dmnrow = 22
 # print(network_domain, n=50)
 # for(dmnrow in 1:nrow(network_domain)){
 for(dmnrow in 1:nrow(network_domain)){
@@ -276,17 +276,17 @@ for(dmnrow in 1:nrow(network_domain)){
                           domain = domain)
 
     ms_retrieve(network = network,
-                # prodname_filter = c('ws_boundary'),
+                prodname_filter = c('ws_boundary'),
                 domain = domain)
     ms_munge(network = network,
-             # prodname_filter = c('ws_boundary'),
+             prodname_filter = c('ws_boundary'),
              domain = domain)
     sw(ms_delineate(network = network,
                     domain = domain,
                     dev_machine_status = ms_instance$machine_status,
                     verbose = TRUE))
     ms_derive(network = network,
-              # prodname_filter = c('ws_boundary'),
+              prodname_filter = c('ws_boundary'),
               domain = domain)
     ms_general(network = network,
                domain = domain)

--- a/src/acquisition_master.R
+++ b/src/acquisition_master.R
@@ -239,7 +239,7 @@ ms_globals <- c(ls(all.names=TRUE), 'ms_globals')
 
 dir.create('logs', showWarnings = FALSE)
 
-# dmnrow = 3
+# dmnrow = 16
 # print(network_domain, n=50)
 # for(dmnrow in 1:nrow(network_domain)){
 for(dmnrow in 1:nrow(network_domain)){

--- a/src/global/general.R
+++ b/src/global/general.R
@@ -15,7 +15,7 @@ unprod <- univ_products %>%
 
 # Load spatial files from Drive if not already held on local machine
 # (takes a long time)
-load_spatial_data()
+# load_spatial_data()
 
 # Load in watershed Boundaries
 files <- list.files(glue('data/{n}/{d}/derived/',
@@ -75,6 +75,7 @@ if(class(gee_file_exist) == 'try-error' || nrow(gee_file_exist) == 0){
 
 # i=19
 for(i in 1:nrow(unprod)){
+# for(i in 3:3){
 
     prodname_ms <- glue(unprod$prodname[i], '__', unprod$prodcode[i])
 

--- a/src/global/global_helpers.R
+++ b/src/global/global_helpers.R
@@ -2581,40 +2581,40 @@ ms_munge <- function(network = domain,
 
     #calculate watershed areas for any provided watershed boundary files,
     #and put them in the site_data file
-    munged_dir <- glue('data/{n}/{d}/munged',
-                       n = network,
-                       d = domain)
-
-    if(dir.exists(munged_dir)){
-        munged_subdirs <- list.dirs(munged_dir,
-                                    recursive = FALSE)
-
-        boundary_ind <- grepl(pattern = 'ws_boundary',
-                              x = munged_subdirs)
-    }
-
-    if(exists('boundary_ind') && any(boundary_ind)){
-
-        boundary_dir <- munged_subdirs[boundary_ind]
-
-        sites <- list.dirs(boundary_dir,
-                           full.names = FALSE,
-                           recursive = FALSE)
-
-        loginfo(logger = logger_module,
-                msg = '(Re)calculating watershed areas for site_data (provided boundaries only)')
-
-    } else {
-        sites <- character()
-    }
-
-    for(s in sites){
-        catch <- ms_calc_watershed_area(network = network,
-                                        domain = domain,
-                                        site_code = s,
-                                        level = 'munged',
-                                        update_site_file = TRUE)
-    }
+    # munged_dir <- glue('data/{n}/{d}/munged',
+    #                    n = network,
+    #                    d = domain)
+    # 
+    # if(dir.exists(munged_dir)){
+    #     munged_subdirs <- list.dirs(munged_dir,
+    #                                 recursive = FALSE)
+    # 
+    #     boundary_ind <- grepl(pattern = 'ws_boundary',
+    #                           x = munged_subdirs)
+    # }
+    # 
+    # if(exists('boundary_ind') && any(boundary_ind)){
+    # 
+    #     boundary_dir <- munged_subdirs[boundary_ind]
+    # 
+    #     sites <- list.dirs(boundary_dir,
+    #                        full.names = FALSE,
+    #                        recursive = FALSE)
+    # 
+    #     loginfo(logger = logger_module,
+    #             msg = '(Re)calculating watershed areas for site_data (provided boundaries only)')
+    # 
+    # } else {
+    #     sites <- character()
+    # }
+    # 
+    # for(s in sites){
+    #     catch <- ms_calc_watershed_area(network = network,
+    #                                     domain = domain,
+    #                                     site_code = s,
+    #                                     level = 'munged',
+    #                                     update_site_file = TRUE)
+    # }
 }
 
 ms_general <- function(network = domain, domain){
@@ -2724,6 +2724,14 @@ ms_delineate <- function(network,
             message(glue('{s} already delineated ({d})',
                          s = site,
                          d = site_dir))
+            
+            #calculate watershed area and write it to site_data gsheet
+            catch <- ms_calc_watershed_area(network = network,
+                                            domain = domain,
+                                            site_code = site,
+                                            level = level,
+                                            update_site_file = TRUE)
+            
             next
         }
 
@@ -2762,6 +2770,12 @@ ms_delineate <- function(network,
                 write_dir = site_dir,
                 verbose = verbose) %>%
                 invisible()
+            
+            catch <- ms_calc_watershed_area(network = network,
+                                            domain = domain,
+                                            site_code = site,
+                                            level = level,
+                                            update_site_file = TRUE)
 
             loginfo(msg = glue('Delineation complete: {n}-{d}-{s}',
                                n = network,
@@ -10081,6 +10095,7 @@ postprocess_entire_dataset <- function(site_data,
 detrmin_mean_record_length <- function(df){
 
     test <- df %>%
+        filter(!is.na(val)) %>%
         filter(Year != year(Sys.Date())) %>%
         group_by(Year, Month, Day) %>%
         summarise(max = max(val, na.rm = TRUE)) %>%

--- a/src/lter/hbef/processing_kernels.R
+++ b/src/lter/hbef/processing_kernels.R
@@ -273,7 +273,7 @@ process_1_94 <- function(network, domain, prodname_ms, site_code,
                       quiet = TRUE) %>%
         # mutate(WSHEDS0_ID = ifelse(is.na(WSHEDS0_ID), 0, WSHEDS0_ID)) %>%
         filter(! is.na(WS), #ignore encompassing, non-experimental watershed
-               site_code != 'w101') %>% #and ungauged w101
+               WS != 'WS101') %>% #and ungauged w101
         select(site_code = WSHEDS0_ID,
                area = AREA,
                perimeter = PERIMETER,

--- a/src/usfs/santee/products.csv
+++ b/src/usfs/santee/products.csv
@@ -3,7 +3,7 @@ VERSIONLESS001,precipitation,ready,ready,NA,precip_pchem_pflux__ms003,NA,precip
 VERSIONLESS002,discharge,ready,ready,NA,stream_flux_inst__ms001,NA,discharge
 VERSIONLESS003,stream_chemistry,ready,ready,NA,stream_flux_inst__ms001,NA,stream_chem
 VERSIONLESS004,precip_chemistry,ready,ready,NA,precip_pchem_pflux__ms003,NA,precip_chem
-VERSIONLESS005,ws_boundary,ready,pending,NA,precip_pchem_pflux__ms003,NA,NA
+VERSIONLESS005,ws_boundary,ready,ready,NA,precip_pchem_pflux__ms003,NA,NA
 ms001,stream_flux_inst,NA,NA,ready,NA,NA,NA
 ms002,precip_gauge_locations,NA,NA,ready,precip_pchem_pflux__ms003,NA,NA
 ms003,precip_pchem_pflux,NA,NA,ready,NA,NA,NA


### PR DESCRIPTION
@vlahm A few small changes here. hbef ws101 is removed from the ws boundaries now, so general products should not be generated for this watershed in the future. 

Santee watersheds are now all coming from santee. The three small catchments: WS80, WS79, and WS77 make sense based on the roads altering flow. WS80 has a part that looks like someone took a bite out of, this is where a culvert was installed which reduces the contributing area to the weir in the early 2000s. The large watershed WS78 looks a little weird around the weir, but due to its size this is probably negligible. 

Watershed area should now only be updated/calculated in ms_delineate. And it should update on every run of the pipeline. 